### PR TITLE
use `#[doc(inline)]` for re-exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod types;
 pub mod userdata;
 pub mod value;
 
+#[doc(inline)]
 pub use self::{
     callback::{BoxSequence, Callback, CallbackFn, CallbackReturn, Sequence, SequencePoll},
     closure::{Closure, ClosureError, FunctionPrototype, PrototypeError},


### PR DESCRIPTION
tbh, it feels like this should be the default for re-exported things. Rust doc search is pretty awful when they aren't inlined, since you end up seeing two items in the results, one of which is the re-export which requires yet another click to get to the page you're actually looking for.

Alternatively, the target of the re-export could be made non-public, which would have the same effect as far as docs go.