### PR TITLE
make math.log match PUC-Lua

### DIFF
--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -126,6 +126,7 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
             None => Some(v.ln()),
             Some(f) if f == 2.0 => Some(v.log2()),
             Some(f) if f == 10.0 => Some(v.log10()),
+            Some(f) if f == core::f64::consts::E => Some(v.ln()),
             Some(base) => Some(v.log(base)),
         }),
     )

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -124,9 +124,6 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
         "log",
         callback("log", &ctx, |_, (v, base): (f64, Option<f64>)| match base {
             None => Some(v.ln()),
-            Some(f) if f == 2.0 => Some(v.log2()),
-            Some(f) if f == 10.0 => Some(v.log10()),
-            Some(f) if f == core::f64::consts::E => Some(v.ln()),
             Some(base) => Some(v.log(base)),
         }),
     )

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -119,13 +119,15 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
 
     math.set(ctx, "huge", Value::Number(f64::INFINITY)).unwrap();
 
-    math.set(ctx, "log", callback("log", &ctx, |_, v: f64| Some(v.ln())))
-        .unwrap();
-
     math.set(
         ctx,
-        "log10",
-        callback("log10", &ctx, |_, v: f64| Some(v.log10())),
+        "log",
+        callback("log", &ctx, |_, (v, base): (f64, Option<f64>)| match base {
+            None => Some(v.ln()),
+            Some(f) if f == 2.0 => Some(v.log2()),
+            Some(f) if f == 10.0 => Some(v.log10()),
+            Some(base) => Some(v.log(base)),
+        }),
     )
     .unwrap();
 

--- a/tests/scripts/math.lua
+++ b/tests/scripts/math.lua
@@ -119,11 +119,11 @@ function test12()
 end
 
 function test13()
-    return math.log10(0) == -math.huge and
-           math.log10(1) == 0.0 and
-           math.log10(10) == 1.0 and
-           math.abs(math.log10(3.1622776601684) - 0.5) < 1e-7 and
-           is_nan(math.log10(-1))
+    return math.log(0, 10) == -math.huge and
+           math.log(1, 10) == 0.0 and
+           math.log(10, 10) == 1.0 and
+           math.abs(math.log(3.1622776601684, 10) - 0.5) < 1e-7 and
+           is_nan(math.log(-1, 10))
 end
 
 function test14()

--- a/tests/scripts/math.lua
+++ b/tests/scripts/math.lua
@@ -122,6 +122,7 @@ function test13()
     return math.log(0, 10) == -math.huge and
            math.log(1, 10) == 0.0 and
            math.log(10, 10) == 1.0 and
+           math.log(math.exp(1), math.exp(1)) == 1.0 and
            math.abs(math.log(3.1622776601684, 10) - 0.5) < 1e-7 and
            is_nan(math.log(-1, 10))
 end


### PR DESCRIPTION
Matches the interface for piccolo's `math.log` function to that of PUC-Lua.

We take advantage of Rust's optimized (?) functions when the requested base matches one of the routines, but we can now handle any base directly.