### PR TITLE
fix: math.random

### DIFF
--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -202,6 +202,7 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
                 let rng = &random_rng;
                 match (a, b) {
                     (None, None) => Some(rng.borrow_mut().gen::<f64>().into()),
+                    (Some(0), None) => Some(rng.borrow_mut().gen::<i64>().into()),
                     (Some(a), None) => Some(rng.borrow_mut().gen_range(1..a + 1).into()),
                     (Some(a), Some(b)) => Some(rng.borrow_mut().gen_range(a..b + 1).into()),
                     _ => None,

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -205,7 +205,7 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
                     (Some(0), None) => Some(rng.borrow_mut().gen::<i64>().into()),
                     (Some(a), None) if a < 0 => None,
                     (Some(a), None) => Some(rng.borrow_mut().gen_range(1..=a).into()),
-                    (Some(a), Some(b)) => Some(rng.borrow_mut().gen_range(a..=b).into()),
+                    (Some(a), Some(b)) if a <= b => Some(rng.borrow_mut().gen_range(a..=b).into()),
                     _ => None,
                 }
             },

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -203,6 +203,7 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
                 match (a, b) {
                     (None, None) => Some(rng.borrow_mut().gen::<f64>().into()),
                     (Some(0), None) => Some(rng.borrow_mut().gen::<i64>().into()),
+                    (Some(a), None) if a < 0 => None,
                     (Some(a), None) => Some(rng.borrow_mut().gen_range(1..a + 1).into()),
                     (Some(a), Some(b)) => Some(rng.borrow_mut().gen_range(a..b + 1).into()),
                     _ => None,

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -204,8 +204,8 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
                     (None, None) => Some(rng.borrow_mut().gen::<f64>().into()),
                     (Some(0), None) => Some(rng.borrow_mut().gen::<i64>().into()),
                     (Some(a), None) if a < 0 => None,
-                    (Some(a), None) => Some(rng.borrow_mut().gen_range(1..a + 1).into()),
-                    (Some(a), Some(b)) => Some(rng.borrow_mut().gen_range(a..b + 1).into()),
+                    (Some(a), None) => Some(rng.borrow_mut().gen_range(1..=a).into()),
+                    (Some(a), Some(b)) => Some(rng.borrow_mut().gen_range(a..=b).into()),
                     _ => None,
                 }
             },

--- a/tests/scripts/math.lua
+++ b/tests/scripts/math.lua
@@ -240,7 +240,7 @@ function test18()
     local dont_crash = math.random(0)
 
     -- this *should* crash though, but not as in a Rust panic crash...
-    local status, _ = pcall(function()
+    local status = pcall(function()
         return math.random(-1)
     end)
     good = good and not status
@@ -251,6 +251,12 @@ function test18()
         local bigboi, bigboi2 = math.random(math.maxinteger), math.random(0, math.maxinteger)
         good = good and bigboi > 0 and bigboi2 > -1
     end
+
+    -- so much violence...
+    local status2 = pcall(function()
+        return math.random(5, 3)
+    end)
+    good = good and not status2
 
     return good
 end

--- a/tests/scripts/math.lua
+++ b/tests/scripts/math.lua
@@ -245,6 +245,13 @@ function test18()
     end)
     good = good and not status
 
+    -- I woke up and chose violence today it seems
+    -- these also should not crash
+    for i = 1, 10000, 1 do
+        local bigboi, bigboi2 = math.random(math.maxinteger), math.random(0, math.maxinteger)
+        good = good and bigboi > 0 and bigboi2 > -1
+    end
+
     return good
 end
 

--- a/tests/scripts/math.lua
+++ b/tests/scripts/math.lua
@@ -239,6 +239,12 @@ function test18()
     -- (randomized bit integer)
     local dont_crash = math.random(0)
 
+    -- this *should* crash though, but not as in a Rust panic crash...
+    local status, _ = pcall(function()
+        return math.random(-1)
+    end)
+    good = good and not status
+
     return good
 end
 

--- a/tests/scripts/math.lua
+++ b/tests/scripts/math.lua
@@ -234,6 +234,11 @@ function test18()
         good = good and numbers1[i] == numbers2[i]
     end
 
+    -- make sure we don't crash when 0 is passed into math.random
+    -- as it is valid for PUC-Lua and has different behavior
+    -- (randomized bit integer)
+    local dont_crash = math.random(0)
+
     return good
 end
 


### PR DESCRIPTION
PUC-Lua has different behavior if `math.random(0)` is executed, as 0 is not in [1, n) for any n.
This changes the code to match that behavior.

Also fixes the crash from `math.random(v)` where `v` < 0 and makes it a Lua error.

I poked the function until it cried, so I included a fix for `math.random([n, ]math.maxinteger)`...