### PR TITLE
String Metatable

### DIFF
--- a/src/lua.rs
+++ b/src/lua.rs
@@ -34,6 +34,11 @@ impl<'gc> Context<'gc> {
         self.state.finalizers
     }
 
+    /// Access to the string metatable
+    pub fn string_metatable(self) -> Table<'gc> {
+        self.state.string_metatable
+    }
+
     /// Calls `ctx.globals().set(ctx, key, value)`.
     pub fn set_global<K: IntoValue<'gc>, V: IntoValue<'gc>>(
         self,
@@ -255,6 +260,14 @@ struct State<'gc> {
     registry: Registry<'gc>,
     strings: InternedStringSet<'gc>,
     finalizers: Finalizers<'gc>,
+
+    // Value metatables. For each non-table non-userdata value,
+    // *all* instances of that value share a metatable.
+    //
+    // Such a metatable is only editable from Lua using
+    // the `debug.setmetatable` function, and passing in
+    // a value of the appropriate type.
+    string_metatable: Table<'gc>,
 }
 
 impl<'gc> State<'gc> {
@@ -264,6 +277,8 @@ impl<'gc> State<'gc> {
             registry: Registry::new(mc),
             strings: InternedStringSet::new(mc),
             finalizers: Finalizers::new(mc),
+
+            string_metatable: Table::new(mc),
         }
     }
 

--- a/src/meta_ops.rs
+++ b/src/meta_ops.rs
@@ -69,6 +69,15 @@ pub fn index<'gc>(
     key: Value<'gc>,
 ) -> Result<MetaResult<'gc, 2>, TypeError> {
     let idx = match table {
+        Value::String(_) => {
+            // We actually don't care what the value is, as for metatable purposes, all strings
+            // share a metatable.
+            let idx = ctx.string_metatable().get(ctx, MetaMethod::Index);
+            if idx.is_nil() {
+                return Ok(MetaResult::Value(Value::Nil));
+            }
+            idx
+        }
         Value::Table(table) => {
             let v = table.get(ctx, key);
             if !v.is_nil() {

--- a/src/stdlib/string.rs
+++ b/src/stdlib/string.rs
@@ -1,4 +1,4 @@
-use crate::{Callback, CallbackReturn, Context, IntoValue, Table, Value};
+use crate::{Callback, CallbackReturn, Context, IntoValue, MetaMethod, Table, Value};
 
 pub fn load_string<'gc>(ctx: Context<'gc>) {
     let string = Table::new(&ctx);
@@ -22,6 +22,11 @@ pub fn load_string<'gc>(ctx: Context<'gc>) {
                 }
             }),
         )
+        .unwrap();
+
+    // Set the string metatable to index from here.
+    ctx.string_metatable()
+        .set(ctx, MetaMethod::Index, string)
         .unwrap();
 
     ctx.set_global("string", string).unwrap();

--- a/tests/scripts/string_metatable.lua
+++ b/tests/scripts/string_metatable.lua
@@ -1,0 +1,5 @@
+local x = "awesome"
+assert(x:len() == 7)
+assert(x.len == string.len)
+
+-- TODO Test the other string module functions once implemented


### PR DESCRIPTION
kickstart a implementation on value metatables.

I did try putting the table in `Context` proper, but I couldn't figure out how to get it to properly reference and was probably doing *something* wrong, but this way worked, so it might be useful for reference or summat.