### PR TITLE
Mirror `__index` change to `__newindex`

### DIFF
--- a/src/meta_ops.rs
+++ b/src/meta_ops.rs
@@ -199,7 +199,7 @@ pub fn new_index<'gc>(
     };
 
     Ok(Some(match idx {
-        Value::Table(table) => MetaCall {
+        table @ (Value::Table(_) | Value::UserData(_)) => MetaCall {
             function: Callback::from_fn(&ctx, |ctx, _, mut stack| {
                 let (table, key, value): (Value, Value, Value) = stack.consume(ctx)?;
                 if let Some(call) = new_index(ctx, table, key, value)? {


### PR DESCRIPTION
realized this should be the case from Lua 5.4 manual:

>Like with indexing, the metavalue for this event can be either a function, a table, or any value with an __newindex metavalue. If it is a function, it is called with table, key, and value as arguments. Otherwise, Lua repeats the indexing assignment over this metavalue with the same key and value. This assignment is regular, not raw, and therefore can trigger another __newindex metavalue.
