### PR TITLE
Add support for basic arithmetic metamethods, improve operator error messages

### DIFF
--- a/src/raw_ops.rs
+++ b/src/raw_ops.rs
@@ -2,20 +2,8 @@ use crate::Value;
 
 // TODO: This module should be entirely replaced by `meta_ops` as they are added.
 
-pub fn add<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.add(&rhs.to_constant()?)?.into())
-}
-
 pub fn subtract<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
     Some(lhs.to_constant()?.subtract(&rhs.to_constant()?)?.into())
-}
-
-pub fn multiply<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.multiply(&rhs.to_constant()?)?.into())
-}
-
-pub fn float_divide<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.float_divide(&rhs.to_constant()?)?.into())
 }
 
 pub fn floor_divide<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {

--- a/src/raw_ops.rs
+++ b/src/raw_ops.rs
@@ -6,46 +6,6 @@ pub fn subtract<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
     Some(lhs.to_constant()?.subtract(&rhs.to_constant()?)?.into())
 }
 
-pub fn floor_divide<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.floor_divide(&rhs.to_constant()?)?.into())
-}
-
-pub fn modulo<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.modulo(&rhs.to_constant()?)?.into())
-}
-
-pub fn exponentiate<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.exponentiate(&rhs.to_constant()?)?.into())
-}
-
-pub fn negate<'gc>(lhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.negate()?.into())
-}
-
-pub fn bitwise_not<'gc>(v: Value<'gc>) -> Option<Value<'gc>> {
-    Some(v.to_constant()?.bitwise_not()?.into())
-}
-
-pub fn bitwise_and<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.bitwise_and(&rhs.to_constant()?)?.into())
-}
-
-pub fn bitwise_or<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.bitwise_or(&rhs.to_constant()?)?.into())
-}
-
-pub fn bitwise_xor<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.bitwise_xor(&rhs.to_constant()?)?.into())
-}
-
-pub fn shift_left<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.shift_left(&rhs.to_constant()?)?.into())
-}
-
-pub fn shift_right<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<Value<'gc>> {
-    Some(lhs.to_constant()?.shift_right(&rhs.to_constant()?)?.into())
-}
-
 pub fn less_than<'gc>(lhs: Value<'gc>, rhs: Value<'gc>) -> Option<bool> {
     Some(lhs.to_constant()?.less_than(&rhs.to_constant()?)?.into())
 }

--- a/src/stdlib/base.rs
+++ b/src/stdlib/base.rs
@@ -147,6 +147,16 @@ pub fn load_base<'gc>(ctx: Context<'gc>) {
     .unwrap();
 
     ctx.set_global(
+        "rawlen",
+        Callback::from_fn(&ctx, |ctx, _, mut stack| {
+            let table: Table = stack.consume(ctx)?;
+            stack.replace(ctx, table.length());
+            Ok(CallbackReturn::Return)
+        }),
+    )
+    .unwrap();
+
+    ctx.set_global(
         "rawset",
         Callback::from_fn(&ctx, |ctx, _, mut stack| {
             let (table, key, value): (Table, Value, Value) = stack.consume(ctx)?;

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -4,8 +4,8 @@ mod vm;
 
 use thiserror::Error;
 
-use crate::meta_ops::MetaCallError;
-use crate::TypeError;
+use crate::meta_ops::{MetaCallError, MetaOperatorError};
+use crate::{BadConcatType, TypeError};
 
 pub use self::{
     executor::{
@@ -13,10 +13,9 @@ pub use self::{
         UpperLuaFrame,
     },
     thread::{BadThreadMode, OpenUpValue, Thread, ThreadInner, ThreadMode},
-    vm::BinaryOperatorError,
 };
 
-#[derive(Debug, Copy, Clone, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum VMError {
     #[error("{}", if *.0 {
         "operation expects variable stack"
@@ -28,6 +27,14 @@ pub enum VMError {
     BadType(#[from] TypeError),
     #[error(transparent)]
     BadCall(#[from] MetaCallError),
+    #[error(transparent)]
+    OperatorError(#[from] MetaOperatorError),
+    #[error(transparent)]
+    BadConcatType(#[from] BadConcatType),
     #[error("_ENV upvalue is only allowed on top-level closure")]
     BadEnvUpValue,
+    #[error("Invalid types in for loop; expected numbers, found {}, {}, and {}", .0, .1, .2)]
+    BadForLoop(&'static str, &'static str, &'static str),
+    #[error("Invalid types in for loop; expected numbers, found {} and {}", .0, .1)]
+    BadForLoopPrep(&'static str, &'static str),
 }

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -4,6 +4,7 @@ mod vm;
 
 use thiserror::Error;
 
+use crate::meta_ops::MetaCallError;
 use crate::TypeError;
 
 pub use self::{
@@ -25,6 +26,8 @@ pub enum VMError {
     ExpectedVariableStack(bool),
     #[error(transparent)]
     BadType(#[from] TypeError),
+    #[error(transparent)]
+    BadCall(#[from] MetaCallError),
     #[error("_ENV upvalue is only allowed on top-level closure")]
     BadEnvUpValue,
 }

--- a/src/thread/vm.rs
+++ b/src/thread/vm.rs
@@ -458,14 +458,34 @@ pub(super) fn run_vm<'gc>(
 
             Operation::Minus { dest, source } => {
                 let value = registers.stack_frame[source.0 as usize];
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::negate(value).ok_or(BinaryOperatorError::UnaryNegate)?;
+                match meta_ops::negate(ctx, value)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::BitNot { dest, source } => {
                 let value = registers.stack_frame[source.0 as usize];
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::bitwise_not(value).ok_or(BinaryOperatorError::BitNot)?;
+                match meta_ops::bitwise_not(ctx, value)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::Add { dest, left, right } => {
@@ -539,57 +559,137 @@ pub(super) fn run_vm<'gc>(
             Operation::IDiv { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::floor_divide(left, right).ok_or(BinaryOperatorError::FloorDivide)?;
+                match meta_ops::floor_divide(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::Mod { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::modulo(left, right).ok_or(BinaryOperatorError::Modulo)?;
+                match meta_ops::modulo(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::Pow { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::exponentiate(left, right).ok_or(BinaryOperatorError::Exponentiate)?;
+                match meta_ops::exponentiate(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::BitAnd { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::bitwise_and(left, right).ok_or(BinaryOperatorError::BitAnd)?;
+                match meta_ops::bitwise_and(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::BitOr { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::bitwise_or(left, right).ok_or(BinaryOperatorError::BitOr)?;
+                match meta_ops::bitwise_or(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::BitXor { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::bitwise_xor(left, right).ok_or(BinaryOperatorError::BitXor)?;
+                match meta_ops::bitwise_xor(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::ShiftLeft { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::shift_left(left, right).ok_or(BinaryOperatorError::ShiftLeft)?;
+                match meta_ops::shift_left(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::ShiftRight { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::shift_right(left, right).ok_or(BinaryOperatorError::ShiftRight)?;
+                match meta_ops::shift_right(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
         }
 

--- a/src/thread/vm.rs
+++ b/src/thread/vm.rs
@@ -471,29 +471,69 @@ pub(super) fn run_vm<'gc>(
             Operation::Add { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::add(left, right).ok_or(BinaryOperatorError::Add)?;
+                match meta_ops::add(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::Sub { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::subtract(left, right).ok_or(BinaryOperatorError::Add)?;
+                match meta_ops::subtract(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::Mul { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::multiply(left, right).ok_or(BinaryOperatorError::Multiply)?;
+                match meta_ops::multiply(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::Div { dest, left, right } => {
                 let left = get_rc(&registers.stack_frame, &current_prototype.constants, left);
                 let right = get_rc(&registers.stack_frame, &current_prototype.constants, right);
-                registers.stack_frame[dest.0 as usize] =
-                    raw_ops::float_divide(left, right).ok_or(BinaryOperatorError::FloatDivide)?;
+                match meta_ops::float_divide(ctx, left, right)? {
+                    MetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    MetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::IDiv { dest, left, right } => {

--- a/tests/scripts/metaop_add.lua
+++ b/tests/scripts/metaop_add.lua
@@ -1,0 +1,77 @@
+do
+    local function add(a, b)
+        return { a.field, b.field }
+    end
+
+    local a = { field = 1 }
+    local b = { field = 4 }
+
+    setmetatable(a, { __add = add })
+
+    local res
+
+    res = a + b
+    assert(#res == 2 and res[1] == a.field and res[2] == b.field)
+    res = b + a
+    assert(#res == 2 and res[1] == b.field and res[2] == a.field)
+
+    setmetatable(a, nil)
+    setmetatable(b, { __add = add })
+
+    res = a + b
+    assert(#res == 2 and res[1] == a.field and res[2] == b.field)
+    res = b + a
+    assert(#res == 2 and res[1] == b.field and res[2] == a.field)
+end
+
+do
+    local function add1(a, b)
+        return { 1, a.field, b.field }
+    end
+    local function add2(a, b)
+        return { 2, a.field, b.field }
+    end
+
+    local a = { field = 1 }
+    local b = { field = 4 }
+
+    setmetatable(a, { __add = add1 })
+    setmetatable(b, { __add = add2 })
+
+    local res
+
+    -- Prioritize __add metaop of first table
+    res = a + b
+    assert(#res == 3 and res[1] == 1 and res[2] == a.field and res[3] == b.field)
+    res = b + a
+    assert(#res == 3 and res[1] == 2 and res[2] == b.field and res[3] == a.field)
+
+    -- If the first table has no __add metaop, try the second
+    setmetatable(a, { })
+    res = a + b
+    assert(#res == 3 and res[1] == 2 and res[2] == a.field and res[3] == b.field)
+    res = b + a
+    assert(#res == 3 and res[1] == 2 and res[2] == b.field and res[3] == a.field)
+
+    setmetatable(a, { __add = add1 })
+    setmetatable(b, { })
+    res = a + b
+    assert(#res == 3 and res[1] == 1 and res[2] == a.field and res[3] == b.field)
+    res = b + a
+    assert(#res == 3 and res[1] == 1 and res[2] == b.field and res[3] == a.field)
+end
+
+do
+    local function add(a, b)
+        return { a, b }
+    end
+
+    local a = { field = 1 }
+    setmetatable(a, { __add = add })
+
+    local res
+    res = a + 3
+    assert(#res == 2 and res[1].field == 1 and res[2] == 3)
+    res = 3 + a
+    assert(#res == 2 and res[1] == 3 and res[2].field == 1)
+end

--- a/tests/scripts/metaops.lua
+++ b/tests/scripts/metaops.lua
@@ -1,6 +1,44 @@
 
+local debug = false
+
+local function dump(obj)
+    if type(obj) == "table" then
+        local s = "{"
+        local seq_len = rawlen(obj)
+        local actual_len = 0
+        for k, v in pairs(obj) do actual_len = actual_len + 1 end
+        if seq_len == actual_len then
+            local sep = " "
+            -- would use ipairs here, but that breaks with the len and index overrides
+            for i = 1, seq_len do
+                s = s .. sep .. dump(rawget(obj, i))
+                sep = ", "
+            end
+        else
+            local sep = " "
+            for k, v in pairs(obj) do
+                if type(k) ~= "string" then
+                    k = "[" .. k .. "]"
+                end
+                s = s .. sep .. k .. " = " .. dump(v)
+                sep = ", "
+            end
+        end
+        s = s .. " }"
+        return s
+    elseif type(obj) == "string" then
+        return '"' .. obj .. '"' -- note: no proper escaping
+    else
+        return tostring(obj)
+    end
+end
+
 local primitives = { ["nil"] = 0, number = 0, string = 0, boolean = 0, ["function"] = 0, thread = 0 }
-local function cmp_array_recurse(a, b)
+local function cmp_array_recurse(a, b, top)
+    if top == nil and debug then
+        print(dump(a))
+        print(dump(b))
+    end
     local a_ty = type(a)
     local b_ty = type(b)
     if a_ty ~= b_ty then
@@ -9,11 +47,11 @@ local function cmp_array_recurse(a, b)
     if primitives[a_ty] ~= nil then
         return a == b
     end
-    if #a ~= #b then
+    if rawlen(a) ~= rawlen(b) then
       return false
     end
-    for i = 1, #a do
-        if not cmp_array_recurse(a[i], b[i]) then
+    for i = 1, rawlen(a) do
+        if not cmp_array_recurse(rawget(a, i), rawget(b, i), false) then
             return false
         end
     end
@@ -52,3 +90,78 @@ do
     res = a * a
     assert(cmp_array_recurse(res, { "mul", { "a" }, { "a" } }))
 end
+
+-- note in the __len docs:
+-- "the result of the call (always adjusted to one value) is the result of the operation"
+do
+    local mt = {
+        __len = function(val) return 5, 6, 7 end,
+    }
+
+    local a = setmetatable({ "a" }, mt)
+    local i, j, k = #a
+    assert(i == 5 and j == nil and k == nil)
+    assert(select("#", #a) == 1)
+end
+
+do
+    local cursed_mt = {}
+    cursed_mt["__add"] = function(a, b) return setmetatable({ "add", a, b }, cursed_mt) end
+    cursed_mt["__sub"] = function(a, b) return setmetatable({ "sub", a, b }, cursed_mt) end
+    cursed_mt["__mul"] = function(a, b) return setmetatable({ "mul", a, b }, cursed_mt) end
+    cursed_mt["__div"] = function(a, b) return setmetatable({ "div", a, b }, cursed_mt) end
+
+    cursed_mt["__mod"] = function(a, b) return setmetatable({ "mod", a, b }, cursed_mt) end
+    cursed_mt["__pow"] = function(a, b) return setmetatable({ "pow", a, b }, cursed_mt) end
+    cursed_mt["__unm"] = function(val) return setmetatable({ "unm", val }, cursed_mt) end
+    cursed_mt["__idiv"] = function(a, b) return setmetatable({ "idiv", a, b }, cursed_mt) end
+
+    cursed_mt["__band"] = function(a, b) return setmetatable({ "band", a, b }, cursed_mt) end
+    cursed_mt["__bor"] = function(a, b) return setmetatable({ "bor", a, b }, cursed_mt) end
+    cursed_mt["__bxor"] = function(a, b) return setmetatable({ "bxor", a, b }, cursed_mt) end
+    cursed_mt["__bnot"] = function(val) return setmetatable({ "bnot", val }, cursed_mt) end
+    cursed_mt["__shl"] = function(a, b) return setmetatable({ "shl", a, b }, cursed_mt) end
+    cursed_mt["__shr"] = function(a, b) return setmetatable({ "shr", a, b }, cursed_mt) end
+
+    cursed_mt["__len"] = function(val) return setmetatable({ "len", val }, cursed_mt) end
+    cursed_mt["__index"] = function(a, b) return setmetatable({ "index", a, b }, cursed_mt) end
+    cursed_mt["__call"] = function(this, ...) return setmetatable({ "call", this, ... }, cursed_mt) end
+
+    -- Not tested here:
+    -- cursed_mt["__newindex"] = function(a, b) end
+    -- cursed_mt["__eq"] = function(a, b) return false end
+    -- cursed_mt["__lt"] = function(a, b) return false end
+    -- cursed_mt["__le"] = function(a, b) return false end
+    -- cursed_mt["__concat"] = function(a, b) return setmetatable({ "concat", a, b }, cursed_mt) end
+
+    local function curse(val)
+        return setmetatable(val, cursed_mt)
+    end
+
+    local a = curse { "a" }
+    local b = curse { "b" }
+
+    assert(cmp_array_recurse(a + b, { "add", { "a" }, { "b" } }))
+    assert(cmp_array_recurse(a - b, { "sub", { "a" }, { "b" } }))
+    assert(cmp_array_recurse(a * b, { "mul", { "a" }, { "b" } }))
+    assert(cmp_array_recurse(a / b, { "div", { "a" }, { "b" } }))
+
+    assert(cmp_array_recurse(a % b, { "mod", { "a" }, { "b" } }))
+    assert(cmp_array_recurse(a ^ b, { "pow", { "a" }, { "b" } }))
+    assert(cmp_array_recurse(-a, { "unm", { "a" } }))
+    assert(cmp_array_recurse(a // b, { "idiv", { "a" }, { "b" } }))
+
+    assert(cmp_array_recurse(a & b, { "band", { "a" }, { "b" } }))
+    assert(cmp_array_recurse(a | b, { "bor", { "a" }, { "b" } }))
+    assert(cmp_array_recurse(a ~ b, { "bxor", { "a" }, { "b" } }))
+    assert(cmp_array_recurse(~a, { "bnot", { "a" } }))
+    assert(cmp_array_recurse(a << b, { "shl", { "a" }, { "b" } }))
+    assert(cmp_array_recurse(a >> b, { "shr", { "a" }, { "b" } }))
+
+    assert(cmp_array_recurse(#a, { "len", { "a" } }))
+    assert(cmp_array_recurse(a.b, { "index", { "a" }, "b" }))
+    assert(cmp_array_recurse(a(), { "call", { "a" } }))
+    assert(cmp_array_recurse(a(1, 2, 3), { "call", { "a" }, 1, 2, 3 }))
+
+end
+

--- a/tests/scripts/metaops.lua
+++ b/tests/scripts/metaops.lua
@@ -1,0 +1,54 @@
+
+local primitives = { ["nil"] = 0, number = 0, string = 0, boolean = 0, ["function"] = 0, thread = 0 }
+local function cmp_array_recurse(a, b)
+    local a_ty = type(a)
+    local b_ty = type(b)
+    if a_ty ~= b_ty then
+        return false
+    end
+    if primitives[a_ty] ~= nil then
+        return a == b
+    end
+    if #a ~= #b then
+      return false
+    end
+    for i = 1, #a do
+        if not cmp_array_recurse(a[i], b[i]) then
+            return false
+        end
+    end
+    return true
+end
+
+do
+    local function add(a, b) return { "add", a, b } end
+    local function sub(a, b) return { "sub", a, b } end
+    local function mul(a, b) return { "mul", a, b } end
+    local function div(a, b) return { "div", a, b } end
+
+    local mt = {
+        __add = add,
+        __sub = sub,
+        __mul = mul,
+        __div = div,
+    }
+
+    local a = { "a" }
+    local b = { "b" }
+    local c = { "c" }
+
+    setmetatable(a, mt)
+    setmetatable(b, mt)
+    setmetatable(c, mt)
+
+    local res
+
+    res = a + b * c - a
+    assert(cmp_array_recurse(res, { "sub", { "add", { "a" }, { "mul", { "b" }, { "c" } } }, { "a" } }))
+
+    res = c / a
+    assert(cmp_array_recurse(res, { "div", { "c" }, { "a" } }))
+
+    res = a * a
+    assert(cmp_array_recurse(res, { "mul", { "a" }, { "a" } }))
+end

--- a/tests/tail_call_stack_panic.rs
+++ b/tests/tail_call_stack_panic.rs
@@ -22,6 +22,6 @@ fn tail_call_stack_panic() {
 
     assert!(matches!(
         lua.execute::<StdString>(&exec),
-        Err(StaticError::Runtime(err)) if matches!(err.downcast::<VMError>(), Some(VMError::BadType(_)))
+        Err(StaticError::Runtime(err)) if matches!(err.downcast::<VMError>(), Some(VMError::BadCall(_)))
     ));
 }


### PR DESCRIPTION
Adds support for the `__add`, `__sub`, `__mul`, and `__div` metamethods.
In addition, this PR adds slightly more context to errors when no metamethod was found; errors include the attempted operation and the relevant types.  (The formatting is done through `thiserror` and the standard formatting machinery.)

The error handling and metamethod changes are in separate commits, for ease of review / cherry-picking.

I implemented this before I saw #57, so feel free to close this if that gets merged. 
I'm mainly creating this PR in case my implementation ends up being helpful; even if this impl isn't used, the test cases are a bit more extensive and could be merged into #57.