### PR TITLE
fix: be correct so we don't burn from Zs

### DIFF
--- a/src/stdlib/base.rs
+++ b/src/stdlib/base.rs
@@ -44,7 +44,16 @@ pub fn load_base<'gc>(ctx: Context<'gc>) {
                         }
                     })
                     .try_fold(0i64, |acc, v| match v {
-                        Some(v) if v < base => Some(acc * base + v),
+                        Some(v) if v < base => {
+                            /*
+                                Unless stated otherwise, any overflow when manipulating integer values wrap
+                                around, according to the usual rules of two-complement arithmetic. (In other
+                                words, the actual result is the unique representable integer that is equal
+                                modulo 2n to the mathematical result, where n is the number of bits of the
+                                integer type.)
+                            */
+                            Some(acc.wrapping_mul(base).wrapping_add(v))
+                        }
                         _ => None,
                     })
                     .map(|v| v * sign);

--- a/src/stdlib/base.rs
+++ b/src/stdlib/base.rs
@@ -44,7 +44,7 @@ pub fn load_base<'gc>(ctx: Context<'gc>) {
                         }
                     })
                     .try_fold(0i64, |acc, v| match v {
-                        Some(v) if v < base => Some(acc.wrapping_mul(base).wrapping_add(v)),
+                        Some(v) if v < base => Some(acc.saturating_mul(base).saturating_add(v)),
                         _ => None,
                     })
                     .map(|v| v * sign);

--- a/src/stdlib/base.rs
+++ b/src/stdlib/base.rs
@@ -47,7 +47,7 @@ pub fn load_base<'gc>(ctx: Context<'gc>) {
                         Some(v) if v < base => Some(acc.wrapping_mul(base).wrapping_add(v)),
                         _ => None,
                     })
-                    .map(|v| v * sign);
+                    .map(|v| v.wrapping_mul(sign));
                 stack.replace(ctx, result.map(Value::Integer).unwrap_or(Value::Nil));
             }
 

--- a/src/stdlib/base.rs
+++ b/src/stdlib/base.rs
@@ -44,7 +44,7 @@ pub fn load_base<'gc>(ctx: Context<'gc>) {
                         }
                     })
                     .try_fold(0i64, |acc, v| match v {
-                        Some(v) if v < base => Some(acc.saturating_mul(base).saturating_add(v)),
+                        Some(v) if v < base => Some(acc.wrapping_mul(base).wrapping_add(v)),
                         _ => None,
                     })
                     .map(|v| v * sign);

--- a/src/stdlib/base.rs
+++ b/src/stdlib/base.rs
@@ -44,16 +44,7 @@ pub fn load_base<'gc>(ctx: Context<'gc>) {
                         }
                     })
                     .try_fold(0i64, |acc, v| match v {
-                        Some(v) if v < base => {
-                            /*
-                                Unless stated otherwise, any overflow when manipulating integer values wrap
-                                around, according to the usual rules of two-complement arithmetic. (In other
-                                words, the actual result is the unique representable integer that is equal
-                                modulo 2n to the mathematical result, where n is the number of bits of the
-                                integer type.)
-                            */
-                            Some(acc.wrapping_mul(base).wrapping_add(v))
-                        }
+                        Some(v) if v < base => Some(acc.wrapping_mul(base).wrapping_add(v)),
                         _ => None,
                     })
                     .map(|v| v * sign);

--- a/tests/scripts/tonumber.lua
+++ b/tests/scripts/tonumber.lua
@@ -27,9 +27,7 @@ do
     assert(tonumber("1 1") == nil)
     assert(tonumber({}) == nil)
     assert(tonumber(nil) == nil)
-    -- This differs from PUC-Rio behavior (which wraps),
-    -- but we don't have to match 1:1.
-    assert(tonumber("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ", 36) == math.maxinteger)
+    assert(tonumber("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ", 36) == -1)
     assert(tonumber("-3.51234567e7") == -35123456.7)
     assert(is_err(function() tonumber(3, 4) end))
     assert(is_err(function() tonumber(3., 4) end))

--- a/tests/scripts/tonumber.lua
+++ b/tests/scripts/tonumber.lua
@@ -27,6 +27,7 @@ do
     assert(tonumber("1 1") == nil)
     assert(tonumber({}) == nil)
     assert(tonumber(nil) == nil)
+    assert(tonumber("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ", 36) == -1)
     assert(tonumber("-3.51234567e7") == -35123456.7)
     assert(is_err(function() tonumber(3, 4) end))
     assert(is_err(function() tonumber(3., 4) end))

--- a/tests/scripts/tonumber.lua
+++ b/tests/scripts/tonumber.lua
@@ -27,7 +27,9 @@ do
     assert(tonumber("1 1") == nil)
     assert(tonumber({}) == nil)
     assert(tonumber(nil) == nil)
-    assert(tonumber("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ", 36) == -1)
+    -- This differs from PUC-Rio behavior (which wraps),
+    -- but we don't have to match 1:1.
+    assert(tonumber("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ", 36) == math.maxinteger)
     assert(tonumber("-3.51234567e7") == -35123456.7)
     assert(is_err(function() tonumber(3, 4) end))
     assert(is_err(function() tonumber(3., 4) end))

--- a/tests/scripts/tonumber.lua
+++ b/tests/scripts/tonumber.lua
@@ -28,6 +28,7 @@ do
     assert(tonumber({}) == nil)
     assert(tonumber(nil) == nil)
     assert(tonumber("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ", 36) == -1)
+    assert(tonumber("-ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZAZZ", 36) == 32401)
     assert(tonumber("-3.51234567e7") == -35123456.7)
     assert(is_err(function() tonumber(3, 4) end))
     assert(is_err(function() tonumber(3., 4) end))


### PR DESCRIPTION
I caught too many Zs...

luckily the manual had something to say about this:
> Unless stated otherwise, any overflow when manipulating integer values wrap around, according to the usual rules of two-complement arithmetic. (In other words, the actual result is the unique representable integer that is equal modulo 2n to the mathematical result, where n is the number of bits of the integer type.)

so here we are

**UPDATE**
> I would be fine with just whatever saturating_add does, even if it doesn't match
> I don't want to mimic weird overflow behavior

kyren has spoken.

**UPDATE UPDATE**

too many Zs spoiled the broth.