### PR TITLE
Unify string conversion logic, remove Value::to_string footgun

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ pub struct LuaError<'gc>(pub Value<'gc>);
 
 impl<'gc> fmt::Display for LuaError<'gc> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.0.display())
     }
 }
 

--- a/src/meta_ops.rs
+++ b/src/meta_ops.rs
@@ -417,7 +417,7 @@ pub fn tostring<'gc>(
 
     Ok(match v {
         v @ Value::String(_) => MetaResult::Value(v),
-        v => MetaResult::Value(ctx.intern(v.to_string().as_bytes()).into()),
+        v => MetaResult::Value(ctx.intern(v.display().to_string().as_bytes()).into()),
     })
 }
 

--- a/src/stdlib/io.rs
+++ b/src/stdlib/io.rs
@@ -35,7 +35,7 @@ pub fn load_io<'gc>(ctx: Context<'gc>) {
                                 } else {
                                     stdout.write_all(b"\t")?;
                                 }
-                                v.display(&mut stdout)?
+                                v.write(&mut stdout)?
                             }
                             MetaResult::Call(call) => {
                                 let bottom = stack.len();

--- a/src/value.rs
+++ b/src/value.rs
@@ -40,20 +40,8 @@ impl<'gc> Value<'gc> {
 
     pub fn write<W: io::Write>(self, mut w: W) -> Result<(), io::Error> {
         match self {
-            Value::Nil => write!(w, "nil"),
-            Value::Boolean(b) => write!(w, "{}", b),
-            Value::Integer(i) => write!(w, "{}", i),
-            Value::Number(f) => write!(w, "{}", f),
             Value::String(s) => w.write_all(s.as_bytes()),
-            Value::Table(t) => write!(w, "<table {:p}>", Gc::as_ptr(t.into_inner())),
-            Value::Function(Function::Closure(c)) => {
-                write!(w, "<function {:p}>", Gc::as_ptr(c.into_inner()))
-            }
-            Value::Function(Function::Callback(c)) => {
-                write!(w, "<function {:p}>", Gc::as_ptr(c.into_inner()))
-            }
-            Value::Thread(t) => write!(w, "<thread {:p}>", Gc::as_ptr(t.into_inner())),
-            Value::UserData(u) => write!(w, "<userdata {:p}>", Gc::as_ptr(u.into_inner())),
+            v => write!(w, "{}", v.display()),
         }
     }
     pub fn display(self) -> impl fmt::Display + 'gc {

--- a/src/value.rs
+++ b/src/value.rs
@@ -38,7 +38,7 @@ impl<'gc> Value<'gc> {
         }
     }
 
-    pub fn display<W: io::Write>(self, mut w: W) -> Result<(), io::Error> {
+    pub fn write<W: io::Write>(self, mut w: W) -> Result<(), io::Error> {
         match self {
             Value::Nil => write!(w, "nil"),
             Value::Boolean(b) => write!(w, "{}", b),
@@ -55,6 +55,9 @@ impl<'gc> Value<'gc> {
             Value::Thread(t) => write!(w, "<thread {:p}>", Gc::as_ptr(t.into_inner())),
             Value::UserData(u) => write!(w, "<userdata {:p}>", Gc::as_ptr(u.into_inner())),
         }
+    }
+    pub fn display(self) -> impl fmt::Display + 'gc {
+        ValueDisplay(self)
     }
 
     pub fn is_nil(self) -> bool {
@@ -91,6 +94,31 @@ impl<'gc> Value<'gc> {
         self.to_constant().and_then(|c| c.to_integer())
     }
 
+    /// Interprets Numbers, Integers, and Strings as a String, if possible.
+    pub fn into_string(self, ctx: crate::Context<'gc>) -> Option<String<'gc>> {
+        match self {
+            Value::Integer(i) => Some(ctx.intern(i.to_string().as_bytes())),
+            Value::Number(n) => Some(ctx.intern(n.to_string().as_bytes())),
+            Value::String(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Indicates whether the value can be implicitly converted to a String;
+    /// if so, [`Value::into_string`] will return `Some` with the same result
+    /// that [`Value::write`] will output.
+    ///
+    /// Note that [`Value::display`] may not result in the same output, when
+    /// handling non-utf8 strings.
+    pub fn is_implicit_string(self) -> bool {
+        match self {
+            Value::Integer(_) => true,
+            Value::Number(_) => true,
+            Value::String(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn to_constant(self) -> Option<Constant<String<'gc>>> {
         match self {
             Value::Nil => Some(Constant::Nil),
@@ -103,12 +131,26 @@ impl<'gc> Value<'gc> {
     }
 }
 
-impl<'gc> fmt::Display for Value<'gc> {
+struct ValueDisplay<'gc>(Value<'gc>);
+
+impl<'gc> fmt::Display for ValueDisplay<'gc> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut buf = Vec::new();
-        self.display(&mut buf).unwrap();
-        let s = StdString::from_utf8_lossy(&buf);
-        write!(fmt, "{}", s)
+        match self.0 {
+            Value::Nil => write!(fmt, "nil"),
+            Value::Boolean(b) => write!(fmt, "{}", b),
+            Value::Integer(i) => write!(fmt, "{}", i),
+            Value::Number(f) => write!(fmt, "{}", f),
+            Value::String(s) => write!(fmt, "{}", StdString::from_utf8_lossy(&s)),
+            Value::Table(t) => write!(fmt, "<table {:p}>", Gc::as_ptr(t.into_inner())),
+            Value::Function(Function::Closure(c)) => {
+                write!(fmt, "<function {:p}>", Gc::as_ptr(c.into_inner()))
+            }
+            Value::Function(Function::Callback(c)) => {
+                write!(fmt, "<function {:p}>", Gc::as_ptr(c.into_inner()))
+            }
+            Value::Thread(t) => write!(fmt, "<thread {:p}>", Gc::as_ptr(t.into_inner())),
+            Value::UserData(u) => write!(fmt, "<userdata {:p}>", Gc::as_ptr(u.into_inner())),
+        }
     }
 }
 

--- a/util/src/serde/de.rs
+++ b/util/src/serde/de.rs
@@ -168,7 +168,8 @@ impl<'gc> de::Deserializer<'gc> for Deserializer<'gc> {
                 Cow::Owned(s) => visitor.visit_string(s),
             }
         } else {
-            visitor.visit_string(self.value.to_string())
+            // Note: this lossily discards non-utf8 data
+            visitor.visit_string(self.value.display().to_string())
         }
     }
 


### PR DESCRIPTION
This makes `Value` no longer directly implement `fmt::Display`, so it no longer has a `to_string` method.  This is probably a good thing, as calling `to_string` would silently corrupt non-utf8 data.

Method changes:
- rename `Value::display` to `Value::write`
- add `Value::display(self) -> impl Display`
- add `Value::into_string(self, ctx) -> Option<String<'gc>>`
- add `Value::is_implicit_string(self) -> bool`

Adds a `FromValue` impl for `string::String<'gc>`

This significantly reduces the boilerplate for stdlib methods that deal with strings.