### PR TITLE
Add wishlist (non-required) tests

### DIFF
--- a/tests/scripts-wishlist/globals.lua
+++ b/tests/scripts-wishlist/globals.lua
@@ -1,0 +1,4 @@
+
+-- Example wishlist test; _G isn't implemented yet, so this will fail.
+
+assert(type(_G) == "table")

--- a/tests/scripts.rs
+++ b/tests/scripts.rs
@@ -7,15 +7,11 @@ use std::{
 
 use piccolo::{io, Closure, Executor, Lua};
 
-#[test]
-fn test_scripts() {
-    const DIR: &str = "./tests/scripts";
+fn run_tests(dir: &str) -> bool {
+    let _ = writeln!(stdout(), "running all test scripts in {dir:?}");
 
     let mut file_failed = false;
-
-    let _ = writeln!(stdout(), "running all test scripts in {DIR:?}");
-
-    for dir in read_dir(DIR).expect("could not list dir contents") {
+    for dir in read_dir(dir).expect("could not list dir contents") {
         let path = dir.expect("could not read dir entry").path();
         let file = io::buffered_read(File::open(&path).unwrap()).unwrap();
         if let Some(ext) = path.extension() {
@@ -38,6 +34,22 @@ fn test_scripts() {
         } else {
             let _ = writeln!(stdout(), "skipping file {:?}", path);
         }
+    }
+    file_failed
+}
+
+#[test]
+fn test_scripts() {
+    let mut file_failed = false;
+
+    file_failed |= run_tests("./tests/scripts");
+
+    let _ = writeln!(stdout(), "Running non-required tests");
+
+    let non_required_failed = run_tests("./tests/scripts-wishlist");
+
+    if non_required_failed {
+        let _ = writeln!(stdout(), "one or more non-required tests failed");
     }
 
     if file_failed {


### PR DESCRIPTION
Simple patch to add support for non-required tests, to make it easier to keep track of lower-priority compatibility bugs.