### PR TITLE
A bunch of small patches

### DIFF
--- a/src/compiler/lexer.rs
+++ b/src/compiler/lexer.rs
@@ -907,17 +907,23 @@ pub fn read_dec_integer(s: &[u8]) -> Option<i64> {
         return None;
     }
 
-    let mut i: i64 = 0;
+    let mut i: u64 = 0;
     for &c in s {
-        let d = from_digit(c)? as i64;
+        let d = from_digit(c)? as u64;
         i = i.checked_mul(10)?.checked_add(d)?;
     }
 
     if is_neg {
-        i = i.checked_neg()?;
+        if i <= i64::MAX as u64 {
+            Some(-(i as i64))
+        } else if i == i64::MAX as u64 + 1 {
+            Some(i64::MIN)
+        } else {
+            None
+        }
+    } else {
+        i.try_into().ok()
     }
-
-    Some(i)
 }
 
 pub fn read_hex_integer(s: &[u8]) -> Option<i64> {
@@ -927,17 +933,23 @@ pub fn read_hex_integer(s: &[u8]) -> Option<i64> {
         return None;
     }
 
-    let mut i: i64 = 0;
+    let mut i: u64 = 0;
     for &c in &s[2..] {
-        let d = from_hex_digit(c)? as i64;
+        let d = from_hex_digit(c)? as u64;
         i = i.checked_mul(16)?.checked_add(d)?;
     }
 
     if is_neg {
-        i = i.checked_neg()?;
+        if i <= i64::MAX as u64 {
+            Some(-(i as i64))
+        } else if i == i64::MAX as u64 + 1 {
+            Some(i64::MIN)
+        } else {
+            None
+        }
+    } else {
+        i.try_into().ok()
     }
-
-    Some(i)
 }
 
 pub fn read_float(s: &[u8]) -> Option<f64> {

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -1168,7 +1168,7 @@ fn binary_priority(operator: BinaryOperator) -> (u8, u8) {
         BinaryOperator::ShiftLeft => (7, 7),
         BinaryOperator::ShiftRight => (7, 7),
         BinaryOperator::Concat => (9, 8),
-        BinaryOperator::NotEqual => (10, 10),
+        BinaryOperator::NotEqual => (3, 3),
         BinaryOperator::Equal => (3, 3),
         BinaryOperator::LessThan => (3, 3),
         BinaryOperator::LessEqual => (3, 3),

--- a/src/stdlib/base.rs
+++ b/src/stdlib/base.rs
@@ -289,7 +289,7 @@ pub fn load_base<'gc>(ctx: Context<'gc>) {
 
     let inext = Callback::from_fn(&ctx, |ctx, _, mut stack| {
         let (table, index): (Value, Option<i64>) = stack.consume(ctx)?;
-        let next_index = index.unwrap_or(0) + 1;
+        let next_index = index.unwrap_or(0).wrapping_add(1);
         Ok(match meta_ops::index(ctx, table, next_index.into())? {
             MetaResult::Value(v) => {
                 if !v.is_nil() {

--- a/tests/scripts/arithmetic.lua
+++ b/tests/scripts/arithmetic.lua
@@ -4,7 +4,7 @@ do
     assert(9223372036854775807 << 0 == 9223372036854775807)
     assert((1 << 63) - 1 == 9223372036854775807)
 
-    -- Shift right is arithmetic (unsigned)
+    -- Shift right is logical (unsigned)
     assert(-1 >> 1 == 9223372036854775807)
 end
 

--- a/tests/scripts/arithmetic.lua
+++ b/tests/scripts/arithmetic.lua
@@ -1,0 +1,28 @@
+
+do
+    assert(1 << 1 == 2)
+    assert(9223372036854775807 << 0 == 9223372036854775807)
+    assert((1 << 63) - 1 == 9223372036854775807)
+
+    -- Shift right is arithmetic (unsigned)
+    assert(-1 >> 1 == 9223372036854775807)
+end
+
+do
+    -- Check overflow cases
+    assert(1 << 64 == 0)
+    assert(-1 >> 64 == 0)
+
+    assert(1 << (1 << 32) == 0)
+    assert(1 >> (1 << 32) == 0)
+end
+
+do
+    assert(0 ~= 1 + 1)
+end
+
+-- Impl bugs caught by PUC-Rio Lua's test suite:
+do
+    local i, j = -16, 3
+    assert(i // j == math.floor(i / j))
+end

--- a/tests/scripts/for.lua
+++ b/tests/scripts/for.lua
@@ -81,10 +81,51 @@ function test_break_scope()
     return true
 end
 
+function test_overflow()
+    local iters = 0
+    for i = math.maxinteger - 32, math.maxinteger, 1 do
+        iters = iters + 1
+        assert(i > 0)
+    end
+    assert(iters == 33)
+
+    iters = 0
+    for i = 0, 10, math.maxinteger do
+        iters = iters + 1
+        assert(i == 0)
+    end
+    assert(iters == 1)
+
+    return true
+end
+
+function test_mixed_floats()
+    -- if initial and step are ints, the loop will use ints,
+    -- even if limit is a float
+    local iters = 0
+    for i = math.maxinteger - 32, math.maxinteger - 0.5, 1 do
+        iters = iters + 1
+        assert(iters < 50)
+    end
+    assert(iters == 33)
+
+    -- loops exit on integer overflow, even if the limit isn't reached
+    iters = 0
+    for i = math.maxinteger - 4, math.huge, 1 do
+        iters = iters + 1
+        assert(iters < 50)
+    end
+    assert(iters == 5)
+
+    return true
+end
+
 assert(
     test_generic() and
     test_numeric() and
     test_numeric_closure() and
     test_generic_closure() and
-    test_break_scope()
+    test_break_scope() and
+    test_mixed_floats() and
+    test_overflow()
 )

--- a/tests/scripts/multi.lua
+++ b/tests/scripts/multi.lua
@@ -57,11 +57,58 @@ local function test6()
     return a == 1 and b == 2 and c == 3
 end
 
+local function test7()
+    local function two(a, b)
+        return a, b
+    end
+
+    local a, b, c, d
+    a, b, c = two(1, 2)
+    assert(a == 1 and b == 2 and c == nil)
+
+    a, b, c = 0, two(1, 2), 0
+    assert(a == 0 and b == 1 and c == 0)
+
+    a, b, c = (two(1, 2))
+    assert(a == 1 and b == nil and c == nil)
+
+    a, b, c, d = 0, (two(1, 2))
+    assert(a == 0 and b == 1 and c == nil and d == nil)
+
+    return true
+end
+
+local function test8()
+    local function ret_all(...)
+        return ...
+    end
+    local function two(a, b)
+        return a, b
+    end
+
+    local a, b, c, d
+    a, b, c = ret_all(two(1, 2))
+    assert(a == 1 and b == 2 and c == nil)
+
+    a, b, c = ret_all(0, two(1, 2), 0)
+    assert(a == 0 and b == 1 and c == 0)
+
+    a, b, c = ret_all((two(1, 2)))
+    assert(a == 1 and b == nil and c == nil)
+
+    a, b, c, d = ret_all(0, (two(1, 2)))
+    assert(a == 0 and b == 1 and c == nil and d == nil)
+
+    return true
+end
+
 assert(
     test1() and
     test2() and
     test3() and
     test4() and
     test5() and
-    test6()
+    test6() and
+    test7() and
+    test8()
 )

--- a/tests/scripts/pairs.lua
+++ b/tests/scripts/pairs.lua
@@ -61,3 +61,10 @@ do
     assert(t2[i] == i, i)
   end
 end
+
+do
+  local t = { [math.mininteger] = 4 }
+  local inext = ipairs(t)
+  local a, b = inext(t, math.maxinteger)
+  assert(a == -9223372036854775808 and b == 4)
+end

--- a/tests/scripts/tonumber.lua
+++ b/tests/scripts/tonumber.lua
@@ -2,6 +2,12 @@ function is_err(f)
     return pcall(f) == false
 end
 
+function roundtrips(orig)
+    local str = tostring(orig)
+    local num = tonumber(str)
+    return num == orig and tostring(num) == str
+end
+
 do
     assert(tonumber("3.4e0") == 3.4)
     assert(tonumber("-3.4") == -3.4)
@@ -33,4 +39,25 @@ do
     assert(is_err(function() tonumber(3, 4) end))
     assert(is_err(function() tonumber(3., 4) end))
     assert(is_err(function() tonumber(nil, 4) end))
+
+    assert(tonumber("15", nil) == 15)
+end
+
+-- Boundary cases
+do
+    assert(roundtrips(math.maxinteger))
+    assert(roundtrips(math.mininteger))
+
+    assert(tonumber("-9223372036854775808") == -9223372036854775807 - 1)
+    -- Use integer wrapping to check that it returned an integer
+    assert(tonumber("-9223372036854775808") - 1 == math.maxinteger)
+
+    -- Value too large, converted to float
+    assert(tostring(tonumber("-9223372036854775809")) ~= "-9223372036854775809")
+
+    assert(tonumber("8000000000000000", 16) == math.mininteger)
+    assert(tonumber("-8000000000000000", 16) == math.mininteger)
+    -- Use integer wrapping to check that it returned an integer
+    assert(tonumber("8000000000000000", 16) - 1 == math.maxinteger)
+    assert(tonumber("-8000000000000000", 16) - 1 == math.maxinteger)
 end


### PR DESCRIPTION
A number of small patches and associated tests:
- Make `tonumber` round-trip `math.integermin` by keeping the value unsigned until the end
- Fix operator precedence of `~=`
- Make integer division (`//`) flooring
- Make bitshifts return 0 on overflow instead of panicking
- Handle integer overflow (and hopefully nans?) in numeric for loops