### PR TITLE
Valid UTF-8 when deserializing on serde

### DIFF
--- a/util/src/serde/de.rs
+++ b/util/src/serde/de.rs
@@ -47,7 +47,7 @@ impl<'gc> de::Deserializer<'gc> for Deserializer<'gc> {
             Value::Integer(_) => self.deserialize_i64(visitor),
             Value::Number(_) => self.deserialize_f64(visitor),
             Value::String(s) => {
-                if let Ok(string) = std::str::from_utf8(s.as_bytes()) {
+                if let Ok(string) = s.to_str() {
                     visitor.visit_borrowed_str(string)
                 } else {
                     self.deserialize_bytes(visitor)

--- a/util/src/serde/de.rs
+++ b/util/src/serde/de.rs
@@ -46,10 +46,13 @@ impl<'gc> de::Deserializer<'gc> for Deserializer<'gc> {
             Value::Boolean(_) => self.deserialize_bool(visitor),
             Value::Integer(_) => self.deserialize_i64(visitor),
             Value::Number(_) => self.deserialize_f64(visitor),
-            Value::String(s) if std::str::from_utf8(s.as_bytes()).is_ok() => {
-                self.deserialize_string(visitor)
+            Value::String(s) => {
+                if let Ok(string) = std::str::from_utf8(s.as_bytes()) {
+                    visitor.visit_borrowed_str(string)
+                } else {
+                    self.deserialize_bytes(visitor)
+                }
             }
-            Value::String(_) => self.deserialize_bytes(visitor),
             Value::Table(t) => {
                 if is_sequence(t) {
                     self.deserialize_seq(visitor)

--- a/util/src/serde/de.rs
+++ b/util/src/serde/de.rs
@@ -46,6 +46,9 @@ impl<'gc> de::Deserializer<'gc> for Deserializer<'gc> {
             Value::Boolean(_) => self.deserialize_bool(visitor),
             Value::Integer(_) => self.deserialize_i64(visitor),
             Value::Number(_) => self.deserialize_f64(visitor),
+            Value::String(s) if std::str::from_utf8(s.as_bytes()).is_ok() => {
+                self.deserialize_string(visitor)
+            }
             Value::String(_) => self.deserialize_bytes(visitor),
             Value::Table(t) => {
                 if is_sequence(t) {
@@ -193,11 +196,7 @@ impl<'gc> de::Deserializer<'gc> for Deserializer<'gc> {
         V: de::Visitor<'gc>,
     {
         if let Value::String(s) = self.value {
-            if let Ok(utf8) = std::str::from_utf8(s.as_bytes()) {
-                visitor.visit_borrowed_str(utf8)
-            } else {
-                visitor.visit_borrowed_bytes(s.as_bytes())
-            }
+            visitor.visit_borrowed_bytes(s.as_bytes())
         } else {
             Err(Error::TypeError {
                 expected: "string",

--- a/util/src/serde/de.rs
+++ b/util/src/serde/de.rs
@@ -193,7 +193,11 @@ impl<'gc> de::Deserializer<'gc> for Deserializer<'gc> {
         V: de::Visitor<'gc>,
     {
         if let Value::String(s) = self.value {
-            visitor.visit_borrowed_bytes(s.as_bytes())
+            if let Ok(utf8) = std::str::from_utf8(s.as_bytes()) {
+                visitor.visit_borrowed_str(utf8)
+            } else {
+                visitor.visit_borrowed_bytes(s.as_bytes())
+            }
         } else {
             Err(Error::TypeError {
                 expected: "string",


### PR DESCRIPTION
When deserializing serde values (that could be anything), if a string only consists of valid UTF-8, attempt to go down the string path.