### PR TITLE
Implement `table.insert` and `table.remove`

### DIFF
--- a/src/fuel.rs
+++ b/src/fuel.rs
@@ -80,3 +80,9 @@ impl Fuel {
         self.fuel > 0 && !self.interrupted
     }
 }
+
+pub(crate) fn count_fuel(per_item: i32, len: usize) -> i32 {
+    i32::try_from(len)
+        .unwrap_or(i32::MAX)
+        .saturating_mul(per_item)
+}

--- a/src/stdlib/table.rs
+++ b/src/stdlib/table.rs
@@ -129,9 +129,8 @@ pub fn load_table<'gc>(ctx: Context<'gc>) {
 
     const FUEL_PER_SHIFTED_ITEM: i32 = 1;
 
-    // Compat note with PRLua:
-    // When the table is empty, table.remove(t, #t) will return nil
-    // (even if the table has a 0 element).
+    // Minor difference from PRLua: When the table is empty, table.remove(t, #t),
+    // will return nil, even if the table has an element at index 0.
     table.set_field(
         ctx,
         "remove",

--- a/src/stdlib/table.rs
+++ b/src/stdlib/table.rs
@@ -1,5 +1,6 @@
 use std::pin::Pin;
 
+use anyhow::Context as _;
 use gc_arena::Collect;
 
 use crate::async_sequence::{
@@ -61,306 +62,321 @@ pub fn load_table<'gc>(ctx: Context<'gc>) {
         }),
     );
 
-    fn prep_metaop_call<'seq, 'gc, const N: usize>(
-        ctx: Context<'gc>,
-        mut stack: Stack<'gc, '_>,
-        locals: Locals<'seq, 'gc>,
-        res: MetaResult<'gc, N>,
-    ) -> Option<LocalFunction<'seq>> {
-        match res {
-            MetaResult::Value(v) => {
-                stack.push_back(v);
-                None
-            }
-            MetaResult::Call(call) => {
-                stack.extend(call.args);
-                Some(locals.stash(&ctx, call.function))
-            }
-        }
-    }
+    table.set_field(ctx, "remove", Callback::from_fn(&ctx, table_remove_impl));
 
-    async fn index_helper<'seq>(
-        seq: &mut AsyncSequence<'seq>,
-        table: &LocalTable<'seq>,
-        key: i64,
-        bottom: usize,
-    ) -> Result<(), LocalError<'seq>> {
-        let call = seq.try_enter(|ctx, locals, _, stack| {
-            let table = locals.fetch(table);
-            let call = meta_ops::index(ctx, Value::Table(table), Value::Integer(key))?;
-            Ok(prep_metaop_call(ctx, stack, locals, call))
-        })?;
-        if let Some(call) = call {
-            seq.call(&call, bottom).await?;
-            seq.enter(|_, _, _, mut stack| {
-                stack.resize(bottom + 1); // Truncate stack
-            });
-        }
-        Ok(())
-    }
-
-    async fn index_set_helper<'seq>(
-        seq: &mut AsyncSequence<'seq>,
-        table: &LocalTable<'seq>,
-        key: i64,
-        value: LocalValue<'seq>,
-        bottom: usize,
-    ) -> Result<(), LocalError<'seq>> {
-        let call = seq.try_enter(|ctx, locals, _, mut stack| {
-            let table = locals.fetch(table);
-            let value = locals.fetch(&value);
-            let call = meta_ops::new_index(ctx, Value::Table(table), Value::Integer(key), value)?;
-            match call {
-                None => Ok(None),
-                Some(call) => {
-                    stack.extend(call.args);
-                    Ok(Some(locals.stash(&ctx, call.function)))
-                }
-            }
-        })?;
-        if let Some(call) = call {
-            seq.call(&call, bottom).await?;
-            seq.enter(|_, _, _, mut stack| {
-                stack.resize(bottom); // Truncate stack
-            });
-        }
-        Ok(())
-    }
-
-    const FUEL_PER_SHIFTED_ITEM: i32 = 1;
-
-    // Minor difference from PRLua: When the table is empty, table.remove(t, #t),
-    // will return nil, even if the table has an element at index 0.
-    table.set_field(
-        ctx,
-        "remove",
-        Callback::from_fn(&ctx, |ctx, mut exec, mut stack| {
-            let (table, index): (Table, Option<i64>) = stack.consume(ctx)?;
-            let length;
-
-            let metatable = table.metatable();
-            let use_fallback = metatable
-                .map(|mt| {
-                    !mt.get(ctx, MetaMethod::Len).is_nil()
-                        || !mt.get(ctx, MetaMethod::Index).is_nil()
-                        || !mt.get(ctx, MetaMethod::NewIndex).is_nil()
-                })
-                .unwrap_or(false);
-
-            if !use_fallback {
-                // Try the fast path
-                let mut inner = table.into_inner().borrow_mut(&ctx);
-                match inner.raw_table.array_remove_shift(index) {
-                    (RawArrayOpResult::Success(val), len) => {
-                        // Consume fuel after the operation to avoid computing length twice
-                        let shifted_items =
-                            len.saturating_sub(index.unwrap_or(len as i64).try_into().unwrap_or(0));
-                        exec.fuel()
-                            .consume(count_fuel(FUEL_PER_SHIFTED_ITEM, shifted_items));
-
-                        stack.push_back(val);
-                        return Ok(CallbackReturn::Return);
-                    }
-                    (RawArrayOpResult::Possible, len) => {
-                        length = Some(len);
-                    }
-                    (RawArrayOpResult::Failed, _) => {
-                        return Err("Invalid index passed to table.remove"
-                            .into_value(ctx)
-                            .into());
-                    }
-                }
-            } else {
-                length = None;
-            }
-
-            // Fast path failed, fall back to direct indexing
-            let s = async_sequence(&ctx, |locals, builder| {
-                let table = locals.stash(&ctx, table);
-                builder.build(|mut seq| async move {
-                    let length = if let Some(len) = length {
-                        len as i64
-                    } else {
-                        let call = seq.try_enter(|ctx, locals, _, stack| {
-                            let table = locals.fetch(&table);
-                            let call = meta_ops::len(ctx, Value::Table(table))?;
-                            Ok(prep_metaop_call(ctx, stack, locals, call))
-                        })?;
-                        if let Some(call) = call {
-                            seq.call(&call, 0).await?;
-                        }
-                        let len = seq.try_enter(|ctx, _, _, mut stack| {
-                            stack.consume::<i64>(ctx).map_err(|e| e.into())
-                        })?;
-                        len
-                    };
-
-                    let index = index.unwrap_or(length);
-
-                    if index == 0 && length == 0 || index == length + 1 {
-                        seq.enter(|_, _, _, mut stack| {
-                            stack.push_back(Value::Nil);
-                        });
-                        Ok(SequenceReturn::Return)
-                    } else if index >= 1 && index <= length {
-                        // Get the value of the element to remove; we'll keep it on the stack.
-                        index_helper(&mut seq, &table, index, 0).await?;
-
-                        // Could make this more efficient by inlining the stack manipulation;
-                        // only pushing the table once.
-                        for i in index..length {
-                            // Push table[i + 1] onto stack
-                            index_helper(&mut seq, &table, i + 1, 1).await?;
-                            let value = seq.enter(|ctx, locals, _, mut stack| {
-                                locals.stash(&ctx, stack.pop_back().unwrap_or_default())
-                            });
-                            // table[i] = table[i + 1]
-                            index_set_helper(&mut seq, &table, i, value, 1).await?;
-
-                            seq.enter(|_, _, mut exec, _| {
-                                exec.fuel().consume(FUEL_PER_SHIFTED_ITEM as i32);
-                            });
-                        }
-
-                        let nil = seq.enter(|ctx, locals, _, _| locals.stash(&ctx, Value::Nil));
-                        // table[length] = nil
-                        index_set_helper(&mut seq, &table, length, nil, 1).await?;
-
-                        // The last value is still on the stack
-                        Ok(SequenceReturn::Return)
-                    } else {
-                        seq.try_enter(|ctx, _, _, _| {
-                            Err("Invalid index passed to table.remove"
-                                .into_value(ctx)
-                                .into())
-                        })
-                    }
-                })
-            });
-            Ok(CallbackReturn::Sequence(s))
-        }),
-    );
-
-    table.set_field(
-        ctx,
-        "insert",
-        Callback::from_fn(&ctx, |ctx, mut exec, mut stack| {
-            let table: Table;
-            let index: Option<i64>;
-            let value: Value;
-            match stack.len() {
-                0..=1 => return Err("Missing arguments to insert".into_value(ctx).into()),
-                2 => {
-                    (table, value) = stack.consume(ctx)?;
-                    index = None;
-                }
-                _ => (table, index, value) = stack.consume(ctx)?,
-            }
-            let length;
-
-            let metatable = table.metatable();
-            let use_fallback = metatable
-                .map(|mt| {
-                    !mt.get(ctx, MetaMethod::Len).is_nil()
-                        || !mt.get(ctx, MetaMethod::Index).is_nil()
-                        || !mt.get(ctx, MetaMethod::NewIndex).is_nil()
-                })
-                .unwrap_or(false);
-
-            if !use_fallback {
-                // Try the fast path
-                match table
-                    .into_inner()
-                    .borrow_mut(&ctx)
-                    .raw_table
-                    .array_insert_shift(index, value)
-                {
-                    (RawArrayOpResult::Success(_), len) => {
-                        // Consume fuel after the operation to avoid computing length twice
-                        let shifted_items = len.saturating_sub(
-                            index
-                                .unwrap_or(len.saturating_add(1) as i64)
-                                .saturating_sub(1)
-                                .try_into()
-                                .unwrap_or(0),
-                        );
-                        exec.fuel()
-                            .consume(count_fuel(FUEL_PER_SHIFTED_ITEM, shifted_items));
-
-                        return Ok(CallbackReturn::Return);
-                    }
-                    (RawArrayOpResult::Possible, len) => {
-                        length = Some(len);
-                    }
-                    (RawArrayOpResult::Failed, _) => {
-                        return Err("Invalid index passed to table.insert"
-                            .into_value(ctx)
-                            .into());
-                    }
-                }
-            } else {
-                length = None;
-            }
-
-            // Fast path failed, fall back to direct indexing
-            let s = async_sequence(&ctx, |locals, builder| {
-                let table = locals.stash(&ctx, table);
-                let value = locals.stash(&ctx, value);
-                builder.build(|mut seq| async move {
-                    let length = if let Some(len) = length {
-                        len as i64
-                    } else {
-                        let call = seq.try_enter(|ctx, locals, _, stack| {
-                            let table = locals.fetch(&table);
-                            let call = meta_ops::len(ctx, Value::Table(table))?;
-                            Ok(prep_metaop_call(ctx, stack, locals, call))
-                        })?;
-                        if let Some(call) = call {
-                            seq.call(&call, 0).await?;
-                        }
-                        let len = seq.try_enter(|ctx, _, _, mut stack| {
-                            stack.consume::<i64>(ctx).map_err(|e| e.into())
-                        })?;
-                        len
-                    };
-
-                    let index = index.unwrap_or(length + 1);
-
-                    if index >= 1 && index <= length + 1 {
-                        // Could make this more efficient by inlining the stack manipulation;
-                        // only pushing the table once.
-                        for i in (index + 1..=length + 1).rev() {
-                            // Push table[i - 1] onto the stack
-                            index_helper(&mut seq, &table, i - 1, 0).await?;
-                            let value = seq.enter(|ctx, locals, _, mut stack| {
-                                locals.stash(&ctx, stack.pop_back().unwrap_or_default())
-                            });
-                            // table[i] = table[i - 1]
-                            index_set_helper(&mut seq, &table, i, value, 0).await?;
-
-                            seq.enter(|_, _, mut exec, _| {
-                                exec.fuel().consume(FUEL_PER_SHIFTED_ITEM as i32);
-                            });
-                        }
-
-                        // table[index] = value
-                        index_set_helper(&mut seq, &table, index, value, 1).await?;
-
-                        Ok(SequenceReturn::Return)
-                    } else {
-                        seq.try_enter(|ctx, _, _, _| {
-                            Err("Invalid index passed to table.insert"
-                                .into_value(ctx)
-                                .into())
-                        })
-                    }
-                })
-            });
-            Ok(CallbackReturn::Sequence(s))
-        }),
-    );
+    table.set_field(ctx, "insert", Callback::from_fn(&ctx, table_insert_impl));
 
     ctx.set_global("table", table);
+}
+
+fn prep_metaop_call<'seq, 'gc, const N: usize>(
+    ctx: Context<'gc>,
+    mut stack: Stack<'gc, '_>,
+    locals: Locals<'seq, 'gc>,
+    res: MetaResult<'gc, N>,
+) -> Option<LocalFunction<'seq>> {
+    match res {
+        MetaResult::Value(v) => {
+            stack.push_back(v);
+            None
+        }
+        MetaResult::Call(call) => {
+            stack.extend(call.args);
+            Some(locals.stash(&ctx, call.function))
+        }
+    }
+}
+
+async fn index_helper<'seq>(
+    seq: &mut AsyncSequence<'seq>,
+    table: &LocalTable<'seq>,
+    key: i64,
+    bottom: usize,
+) -> Result<(), LocalError<'seq>> {
+    let call = seq.try_enter(|ctx, locals, _, stack| {
+        let table = locals.fetch(table);
+        let call = meta_ops::index(ctx, Value::Table(table), Value::Integer(key))?;
+        Ok(prep_metaop_call(ctx, stack, locals, call))
+    })?;
+    if let Some(call) = call {
+        seq.call(&call, bottom).await?;
+        seq.enter(|_, _, _, mut stack| {
+            stack.resize(bottom + 1); // Truncate stack
+        });
+    }
+    Ok(())
+}
+
+async fn index_set_helper<'seq>(
+    seq: &mut AsyncSequence<'seq>,
+    table: &LocalTable<'seq>,
+    key: i64,
+    value: LocalValue<'seq>,
+    bottom: usize,
+) -> Result<(), LocalError<'seq>> {
+    let call = seq.try_enter(|ctx, locals, _, mut stack| {
+        let table = locals.fetch(table);
+        let value = locals.fetch(&value);
+        let call = meta_ops::new_index(ctx, Value::Table(table), Value::Integer(key), value)?;
+        match call {
+            None => Ok(None),
+            Some(call) => {
+                stack.extend(call.args);
+                Ok(Some(locals.stash(&ctx, call.function)))
+            }
+        }
+    })?;
+    if let Some(call) = call {
+        seq.call(&call, bottom).await?;
+        seq.enter(|_, _, _, mut stack| {
+            stack.resize(bottom); // Truncate stack
+        });
+    }
+    Ok(())
+}
+
+const FUEL_PER_SHIFTED_ITEM: i32 = 1;
+
+// Minor difference from PRLua: When the table is empty, table.remove(t, #t),
+// will return nil, even if the table has an element at index 0.
+fn table_remove_impl<'gc>(
+    ctx: Context<'gc>,
+    mut exec: Execution<'gc, '_>,
+    mut stack: Stack<'gc, '_>,
+) -> Result<CallbackReturn<'gc>, Error<'gc>> {
+    let (table, index): (Table, Option<i64>) = stack.consume(ctx)?;
+    let length;
+
+    let metatable = table.metatable();
+    let use_fallback = metatable
+        .map(|mt| {
+            !mt.get(ctx, MetaMethod::Len).is_nil()
+                || !mt.get(ctx, MetaMethod::Index).is_nil()
+                || !mt.get(ctx, MetaMethod::NewIndex).is_nil()
+        })
+        .unwrap_or(false);
+
+    if !use_fallback {
+        // Try the fast path
+        let mut inner = table.into_inner().borrow_mut(&ctx);
+        match inner.raw_table.array_remove_shift(index) {
+            (RawArrayOpResult::Success(val), len) => {
+                // Consume fuel after the operation to avoid computing length twice
+                let shifted_items =
+                    len.saturating_sub(index.unwrap_or(len as i64).try_into().unwrap_or(0));
+                exec.fuel()
+                    .consume(count_fuel(FUEL_PER_SHIFTED_ITEM, shifted_items));
+
+                stack.push_back(val);
+                return Ok(CallbackReturn::Return);
+            }
+            (RawArrayOpResult::Possible, len) => {
+                length = Some(len);
+            }
+            (RawArrayOpResult::Failed, _) => {
+                return Err("Invalid index passed to table.remove"
+                    .into_value(ctx)
+                    .into());
+            }
+        }
+    } else {
+        length = None;
+    }
+
+    // Fast path failed, fall back to direct indexing
+    let s = async_sequence(&ctx, |locals, builder| {
+        let table = locals.stash(&ctx, table);
+        builder.build(|mut seq| async move {
+            let length = if let Some(len) = length {
+                len as i64
+            } else {
+                let call = seq.try_enter(|ctx, locals, _, stack| {
+                    let table = locals.fetch(&table);
+                    let call = meta_ops::len(ctx, Value::Table(table))
+                        .context("error while calling __len")?;
+                    Ok(prep_metaop_call(ctx, stack, locals, call))
+                })?;
+                if let Some(call) = call {
+                    seq.call(&call, 0).await?;
+                }
+                let len = seq.try_enter(|ctx, _, _, mut stack| {
+                    Ok(stack
+                        .consume::<i64>(ctx)
+                        .context("__len returned invalid length")?)
+                })?;
+                len
+            };
+
+            let index = index.unwrap_or(length);
+
+            if index == 0 && length == 0 || index == length + 1 {
+                seq.enter(|_, _, _, mut stack| {
+                    stack.push_back(Value::Nil);
+                });
+                Ok(SequenceReturn::Return)
+            } else if index >= 1 && index <= length {
+                // Get the value of the element to remove; we'll keep it on the stack.
+                index_helper(&mut seq, &table, index, 0).await?;
+
+                // Could make this more efficient by inlining the stack manipulation;
+                // only pushing the table once.
+                for i in index..length {
+                    // Push table[i + 1] onto stack
+                    index_helper(&mut seq, &table, i + 1, 1).await?;
+                    let value = seq.enter(|ctx, locals, _, mut stack| {
+                        locals.stash(&ctx, stack.pop_back().unwrap_or_default())
+                    });
+                    // table[i] = table[i + 1]
+                    index_set_helper(&mut seq, &table, i, value, 1).await?;
+
+                    seq.enter(|_, _, mut exec, _| {
+                        exec.fuel().consume(FUEL_PER_SHIFTED_ITEM as i32);
+                    });
+                }
+
+                let nil = seq.enter(|ctx, locals, _, _| locals.stash(&ctx, Value::Nil));
+                // table[length] = nil
+                index_set_helper(&mut seq, &table, length, nil, 1).await?;
+
+                // The last value is still on the stack
+                Ok(SequenceReturn::Return)
+            } else {
+                seq.try_enter(|ctx, _, _, _| {
+                    Err("Invalid index passed to table.remove"
+                        .into_value(ctx)
+                        .into())
+                })
+            }
+        })
+    });
+    Ok(CallbackReturn::Sequence(s))
+}
+
+fn table_insert_impl<'gc>(
+    ctx: Context<'gc>,
+    mut exec: Execution<'gc, '_>,
+    mut stack: Stack<'gc, '_>,
+) -> Result<CallbackReturn<'gc>, Error<'gc>> {
+    let table: Table;
+    let index: Option<i64>;
+    let value: Value;
+    match stack.len() {
+        0..=1 => return Err("Missing arguments to insert".into_value(ctx).into()),
+        2 => {
+            (table, value) = stack.consume(ctx)?;
+            index = None;
+        }
+        _ => {
+            let i: i64;
+            // Index must not be nil
+            (table, i, value) = stack.consume(ctx)?;
+            index = Some(i);
+        }
+    }
+    let length;
+
+    let metatable = table.metatable();
+    let use_fallback = metatable
+        .map(|mt| {
+            !mt.get(ctx, MetaMethod::Len).is_nil()
+                || !mt.get(ctx, MetaMethod::Index).is_nil()
+                || !mt.get(ctx, MetaMethod::NewIndex).is_nil()
+        })
+        .unwrap_or(false);
+
+    if !use_fallback {
+        // Try the fast path
+        match table
+            .into_inner()
+            .borrow_mut(&ctx)
+            .raw_table
+            .array_insert_shift(index, value)
+        {
+            (RawArrayOpResult::Success(_), len) => {
+                // Consume fuel after the operation to avoid computing length twice
+                let shifted_items = len.saturating_sub(
+                    index
+                        .unwrap_or(len.saturating_add(1) as i64)
+                        .saturating_sub(1)
+                        .try_into()
+                        .unwrap_or(0),
+                );
+                exec.fuel()
+                    .consume(count_fuel(FUEL_PER_SHIFTED_ITEM, shifted_items));
+
+                return Ok(CallbackReturn::Return);
+            }
+            (RawArrayOpResult::Possible, len) => {
+                length = Some(len);
+            }
+            (RawArrayOpResult::Failed, _) => {
+                return Err("Invalid index passed to table.insert"
+                    .into_value(ctx)
+                    .into());
+            }
+        }
+    } else {
+        length = None;
+    }
+
+    // Fast path failed, fall back to direct indexing
+    let s = async_sequence(&ctx, |locals, builder| {
+        let table = locals.stash(&ctx, table);
+        let value = locals.stash(&ctx, value);
+        builder.build(|mut seq| async move {
+            let length = if let Some(len) = length {
+                len as i64
+            } else {
+                let call = seq.try_enter(|ctx, locals, _, stack| {
+                    let table = locals.fetch(&table);
+                    let call = meta_ops::len(ctx, Value::Table(table))
+                        .context("error while calling __len")?;
+                    Ok(prep_metaop_call(ctx, stack, locals, call))
+                })?;
+                if let Some(call) = call {
+                    seq.call(&call, 0).await?;
+                }
+                let len = seq.try_enter(|ctx, _, _, mut stack| {
+                    Ok(stack
+                        .consume::<i64>(ctx)
+                        .context("__len returned invalid length")?)
+                })?;
+                len
+            };
+
+            let index = index.unwrap_or(length + 1);
+
+            if index >= 1 && index <= length + 1 {
+                // Could make this more efficient by inlining the stack manipulation;
+                // only pushing the table once.
+                for i in (index + 1..=length + 1).rev() {
+                    // Push table[i - 1] onto the stack
+                    index_helper(&mut seq, &table, i - 1, 0).await?;
+                    let value = seq.enter(|ctx, locals, _, mut stack| {
+                        locals.stash(&ctx, stack.pop_back().unwrap_or_default())
+                    });
+                    // table[i] = table[i - 1]
+                    index_set_helper(&mut seq, &table, i, value, 0).await?;
+
+                    seq.enter(|_, _, mut exec, _| {
+                        exec.fuel().consume(FUEL_PER_SHIFTED_ITEM as i32);
+                    });
+                }
+
+                // table[index] = value
+                index_set_helper(&mut seq, &table, index, value, 0).await?;
+
+                Ok(SequenceReturn::Return)
+            } else {
+                seq.try_enter(|ctx, _, _, _| {
+                    Err("Invalid index passed to table.insert"
+                        .into_value(ctx)
+                        .into())
+                })
+            }
+        })
+    });
+    Ok(CallbackReturn::Sequence(s))
 }
 
 const PACK_ELEMS_PER_FUEL: usize = 8;

--- a/src/stdlib/table.rs
+++ b/src/stdlib/table.rs
@@ -2,11 +2,14 @@ use std::pin::Pin;
 
 use gc_arena::Collect;
 
+use crate::async_sequence::{
+    AsyncSequence, LocalError, LocalFunction, LocalTable, LocalValue, Locals,
+};
 use crate::meta_ops::{self, MetaResult};
 use crate::table::RawArrayOpResult;
 use crate::{
-    BoxSequence, Callback, CallbackReturn, Context, Error, Execution, IntoValue, Sequence,
-    SequencePoll, Stack, Table, Value,
+    async_sequence, BoxSequence, Callback, CallbackReturn, Context, Error, Execution, IntoValue,
+    MetaMethod, Sequence, SequencePoll, SequenceReturn, Stack, Table, Value,
 };
 
 pub fn load_table<'gc>(ctx: Context<'gc>) {
@@ -57,6 +60,75 @@ pub fn load_table<'gc>(ctx: Context<'gc>) {
         }),
     );
 
+    fn prep_metaop_call<'seq, 'gc, const N: usize>(
+        ctx: Context<'gc>,
+        mut stack: Stack<'gc, '_>,
+        locals: Locals<'seq, 'gc>,
+        res: MetaResult<'gc, N>,
+    ) -> Option<LocalFunction<'seq>> {
+        match res {
+            MetaResult::Value(v) => {
+                stack.push_back(v);
+                None
+            }
+            MetaResult::Call(call) => {
+                stack.extend(call.args);
+                Some(locals.stash(&ctx, call.function))
+            }
+        }
+    }
+
+    async fn index_helper<'seq>(
+        seq: &mut AsyncSequence<'seq>,
+        table: &LocalTable<'seq>,
+        key: i64,
+        bottom: usize,
+    ) -> Result<(), LocalError<'seq>> {
+        let call = seq.try_enter(|ctx, locals, _, stack| {
+            let table = locals.fetch(table);
+            let call = meta_ops::index(ctx, Value::Table(table), Value::Integer(key))?;
+            Ok(prep_metaop_call(ctx, stack, locals, call))
+        })?;
+        if let Some(call) = call {
+            seq.call(&call, bottom).await?;
+            seq.enter(|_, _, _, mut stack| {
+                stack.resize(bottom + 1); // Truncate stack
+            });
+        }
+        Ok(())
+    }
+
+    async fn index_set_helper<'seq>(
+        seq: &mut AsyncSequence<'seq>,
+        table: &LocalTable<'seq>,
+        key: i64,
+        value: LocalValue<'seq>,
+        bottom: usize,
+    ) -> Result<(), LocalError<'seq>> {
+        let call = seq.try_enter(|ctx, locals, _, mut stack| {
+            let table = locals.fetch(table);
+            let value = locals.fetch(&value);
+            let call = meta_ops::new_index(ctx, Value::Table(table), Value::Integer(key), value)?;
+            match call {
+                None => Ok(None),
+                Some(call) => {
+                    stack.extend(call.args);
+                    Ok(Some(locals.stash(&ctx, call.function)))
+                }
+            }
+        })?;
+        if let Some(call) = call {
+            seq.call(&call, bottom).await?;
+            seq.enter(|_, _, _, mut stack| {
+                stack.resize(bottom); // Truncate stack
+            });
+        }
+        Ok(())
+    }
+
+    // Compat note with PRLua:
+    // When the table is empty, table.remove(t, #t) will return nil
+    // (even if the table has a 0 element).
     table.set_field(
         ctx,
         "remove",
@@ -64,46 +136,96 @@ pub fn load_table<'gc>(ctx: Context<'gc>) {
             let (table, index): (Table, Option<i64>) = stack.consume(ctx)?;
             let length;
 
-            // Try the fast path
-            match table
-                .into_inner()
-                .borrow_mut(&ctx)
-                .raw_table
-                .array_remove_shift(index)
-            {
-                (RawArrayOpResult::Success(val), _) => {
-                    stack.push_back(val);
-                    return Ok(CallbackReturn::Return);
+            let metatable = table.metatable();
+            let use_fallback = metatable
+                .map(|mt| {
+                    !mt.get(ctx, MetaMethod::Len).is_nil()
+                        || !mt.get(ctx, MetaMethod::Index).is_nil()
+                        || !mt.get(ctx, MetaMethod::NewIndex).is_nil()
+                })
+                .unwrap_or(false);
+
+            if !use_fallback {
+                // Try the fast path
+                let mut inner = table.into_inner().borrow_mut(&ctx);
+                match inner.raw_table.array_remove_shift(index) {
+                    (RawArrayOpResult::Success(val), _) => {
+                        stack.push_back(val);
+                        return Ok(CallbackReturn::Return);
+                    }
+                    (RawArrayOpResult::Possible, len) => {
+                        length = Some(len);
+                    }
+                    (RawArrayOpResult::Failed, _) => {
+                        return Err("Invalid index passed to table.remove"
+                            .into_value(ctx)
+                            .into());
+                    }
                 }
-                (RawArrayOpResult::Possible, len) => length = len,
-                (RawArrayOpResult::Failed, _) => {
-                    return Err("Invalid index passed to table.remove"
-                        .into_value(ctx)
-                        .into());
-                }
+            } else {
+                length = None;
             }
 
             // Fast path failed, fall back to direct indexing
-            // TODO: variant that respects metamethods?
-            let length = length as i64;
-            let index = index.unwrap_or(length);
+            let s = async_sequence(&ctx, |locals, builder| {
+                let table = locals.stash(&ctx, table);
+                builder.build(|mut seq| async move {
+                    let length = if let Some(len) = length {
+                        len as i64
+                    } else {
+                        let call = seq.try_enter(|ctx, locals, _, stack| {
+                            let table = locals.fetch(&table);
+                            let call = meta_ops::len(ctx, Value::Table(table))?;
+                            Ok(prep_metaop_call(ctx, stack, locals, call))
+                        })?;
+                        if let Some(call) = call {
+                            seq.call(&call, 0).await?;
+                        }
+                        let len = seq.try_enter(|ctx, _, _, mut stack| {
+                            stack.consume::<i64>(ctx).map_err(|e| e.into())
+                        })?;
+                        len
+                    };
 
-            if index == 0 && length == 0 || index == length + 1 {
-                stack.push_back(Value::Nil);
-                Ok(CallbackReturn::Return)
-            } else if index >= 1 && index <= length {
-                let mut prev = Value::Nil;
-                for i in (index..=length).rev() {
-                    prev = table.set(ctx, i, prev)?;
-                }
-                // Last value is the value at index
-                stack.push_back(prev);
-                Ok(CallbackReturn::Return)
-            } else {
-                Err("Invalid index passed to table.remove"
-                    .into_value(ctx)
-                    .into())
-            }
+                    let index = index.unwrap_or(length);
+
+                    if index == 0 && length == 0 || index == length + 1 {
+                        seq.enter(|_, _, _, mut stack| {
+                            stack.push_back(Value::Nil);
+                        });
+                        Ok(SequenceReturn::Return)
+                    } else if index >= 1 && index <= length {
+                        // Get the value of the element to remove; we'll keep it on the stack.
+                        index_helper(&mut seq, &table, index, 0).await?;
+
+                        // Could make this more efficient by inlining the stack manipulation;
+                        // only pushing the table once.
+                        for i in index..length {
+                            // Push table[i + 1] onto stack
+                            index_helper(&mut seq, &table, i + 1, 1).await?;
+                            let value = seq.enter(|ctx, locals, _, mut stack| {
+                                locals.stash(&ctx, stack.pop_back().unwrap_or_default())
+                            });
+                            // table[i] = table[i + 1]
+                            index_set_helper(&mut seq, &table, i, value, 1).await?;
+                        }
+
+                        let nil = seq.enter(|ctx, locals, _, _| locals.stash(&ctx, Value::Nil));
+                        // table[length] = nil
+                        index_set_helper(&mut seq, &table, length, nil, 1).await?;
+
+                        // The last value is still on the stack
+                        Ok(SequenceReturn::Return)
+                    } else {
+                        seq.try_enter(|ctx, _, _, _| {
+                            Err("Invalid index passed to table.remove"
+                                .into_value(ctx)
+                                .into())
+                        })
+                    }
+                })
+            });
+            Ok(CallbackReturn::Sequence(s))
         }),
     );
 
@@ -122,45 +244,92 @@ pub fn load_table<'gc>(ctx: Context<'gc>) {
                 }
                 _ => (table, index, value) = stack.consume(ctx)?,
             }
-
             let length;
 
-            // Try the fast path
-            match table
-                .into_inner()
-                .borrow_mut(&ctx)
-                .raw_table
-                .array_insert_shift(index, value)
-            {
-                (RawArrayOpResult::Success(_), _) => {
-                    return Ok(CallbackReturn::Return);
+            let metatable = table.metatable();
+            let use_fallback = metatable
+                .map(|mt| {
+                    !mt.get(ctx, MetaMethod::Len).is_nil()
+                        || !mt.get(ctx, MetaMethod::Index).is_nil()
+                        || !mt.get(ctx, MetaMethod::NewIndex).is_nil()
+                })
+                .unwrap_or(false);
+
+            if !use_fallback {
+                // Try the fast path
+                match table
+                    .into_inner()
+                    .borrow_mut(&ctx)
+                    .raw_table
+                    .array_insert_shift(index, value)
+                {
+                    (RawArrayOpResult::Success(_), _) => {
+                        return Ok(CallbackReturn::Return);
+                    }
+                    (RawArrayOpResult::Possible, len) => {
+                        length = Some(len);
+                    }
+                    (RawArrayOpResult::Failed, _) => {
+                        return Err("Invalid index passed to table.insert"
+                            .into_value(ctx)
+                            .into());
+                    }
                 }
-                (RawArrayOpResult::Possible, len) => length = len,
-                (RawArrayOpResult::Failed, _) => {
-                    return Err("Invalid index passed to table.insert"
-                        .into_value(ctx)
-                        .into());
-                }
+            } else {
+                length = None;
             }
 
             // Fast path failed, fall back to direct indexing
-            // TODO: variant that respects metamethods?
-            let length = length as i64;
-            let index = index.unwrap_or(length + 1);
+            let s = async_sequence(&ctx, |locals, builder| {
+                let table = locals.stash(&ctx, table);
+                let value = locals.stash(&ctx, value);
+                builder.build(|mut seq| async move {
+                    let length = if let Some(len) = length {
+                        len as i64
+                    } else {
+                        let call = seq.try_enter(|ctx, locals, _, stack| {
+                            let table = locals.fetch(&table);
+                            let call = meta_ops::len(ctx, Value::Table(table))?;
+                            Ok(prep_metaop_call(ctx, stack, locals, call))
+                        })?;
+                        if let Some(call) = call {
+                            seq.call(&call, 0).await?;
+                        }
+                        let len = seq.try_enter(|ctx, _, _, mut stack| {
+                            stack.consume::<i64>(ctx).map_err(|e| e.into())
+                        })?;
+                        len
+                    };
 
-            if index >= 1 && index <= length + 1 {
-                let mut prev = value;
-                for i in index..=length + 1 {
-                    prev = table.set(ctx, i, prev)?;
-                }
-                // Last value is the value at index
-                stack.push_back(prev);
-                Ok(CallbackReturn::Return)
-            } else {
-                Err("Invalid index passed to table.insert"
-                    .into_value(ctx)
-                    .into())
-            }
+                    let index = index.unwrap_or(length + 1);
+
+                    if index >= 1 && index <= length + 1 {
+                        // Could make this more efficient by inlining the stack manipulation;
+                        // only pushing the table once.
+                        for i in (index + 1..=length + 1).rev() {
+                            // Push table[i - 1] onto the stack
+                            index_helper(&mut seq, &table, i - 1, 0).await?;
+                            let value = seq.enter(|ctx, locals, _, mut stack| {
+                                locals.stash(&ctx, stack.pop_back().unwrap_or_default())
+                            });
+                            // table[i] = table[i - 1]
+                            index_set_helper(&mut seq, &table, i, value, 0).await?;
+                        }
+
+                        // table[index] = value
+                        index_set_helper(&mut seq, &table, index, value, 1).await?;
+
+                        Ok(SequenceReturn::Return)
+                    } else {
+                        seq.try_enter(|ctx, _, _, _| {
+                            Err("Invalid index passed to table.insert"
+                                .into_value(ctx)
+                                .into())
+                        })
+                    }
+                })
+            });
+            Ok(CallbackReturn::Sequence(s))
         }),
     );
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -2,6 +2,6 @@ mod raw;
 mod table;
 
 pub use self::{
-    raw::{InvalidTableKey, NextValue, RawTable},
+    raw::{InvalidTableKey, NextValue, RawArrayOpResult, RawTable},
     table::{Table, TableInner, TableState},
 };

--- a/src/table/raw.rs
+++ b/src/table/raw.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, fmt, hash::Hash, i64, mem};
+use std::{fmt, hash::Hash, i64, mem};
 
 use allocator_api2::vec;
 use gc_arena::{allocator_api::MetricsAlloc, Collect, Gc, Mutation};
@@ -142,100 +142,7 @@ impl<'gc> RawTable<'gc> {
         } else if self.map.len() < self.map.capacity() {
             set_reserved_value(&mut self.map, hash, table_key, value)
         } else {
-            // If a new element does not fit in either the array or map part of the table, we need
-            // to grow. First, we find the total count of array candidate elements across the array
-            // part, the map part, and the newly inserted key.
-
-            const USIZE_BITS: usize = mem::size_of::<usize>() * 8;
-
-            // Count of array-candidate elements based on the highest bit in the index
-            let mut array_counts = [0; USIZE_BITS];
-            // Total count of all array-candidate elements
-            let mut array_total = 0;
-
-            for (i, e) in self.array.iter().enumerate() {
-                if !e.is_nil() {
-                    array_counts[highest_bit(i)] += 1;
-                    array_total += 1;
-                }
-            }
-
-            for (&key, &value) in &self.map {
-                if !value.is_nil() {
-                    if let Some(i) = to_array_index(
-                        key.live_key()
-                            .expect("dead keys must have Nil values")
-                            .to_value(),
-                    ) {
-                        array_counts[highest_bit(i)] += 1;
-                        array_total += 1;
-                    }
-                }
-            }
-
-            if let Some(i) = index_key {
-                array_counts[highest_bit(i)] += 1;
-                array_total += 1;
-            }
-
-            // Then, we compute the new optimal size for the array by finding the largest array size
-            // such that at least half of the elements in the array would be in use.
-
-            let mut optimal_size = 0;
-            let mut total = 0;
-            for i in 0..USIZE_BITS {
-                if (1 << i) / 2 >= array_total {
-                    break;
-                }
-
-                if array_counts[i] > 0 {
-                    total += array_counts[i];
-                    if total > (1 << i) / 2 {
-                        optimal_size = 1 << i;
-                    }
-                }
-            }
-
-            let old_array_size = self.array.len();
-            let old_map_size = self.map.len();
-            if optimal_size > old_array_size {
-                // If we're growing the array part, we need to grow the array and take any newly
-                // valid array keys from the map part.
-
-                self.array.reserve(optimal_size - old_array_size);
-                let capacity = self.array.capacity();
-                self.array.resize(capacity, Value::Nil);
-
-                let array = &mut self.array;
-                self.map.retain(|k, v| {
-                    if v.is_nil() {
-                        // If our entry is dead, remove it.
-                        return false;
-                    }
-
-                    let key = k.live_key().expect("all dead keys should have a Nil value");
-
-                    // If our live key is an array index that fits in the array portion,
-                    // move the entry to the array portion.
-                    if let Some(i) = to_array_index(key.to_value()) {
-                        if i < array.len() {
-                            array[i] = *v;
-                            return false;
-                        }
-                    }
-
-                    true
-                });
-            } else {
-                // If we aren't growing the array, we're adding a new element to the map that won't
-                // fit in the advertised capacity. We explicitly double the map size here.
-                self.map.raw_table_mut().reserve(old_map_size, |(key, _)| {
-                    self.hash_builder.hash_one(
-                        key.live_key()
-                            .expect("all keys must be live when table is grown"),
-                    )
-                });
-            }
+            self.grow(index_key);
 
             // Now we can insert the new key value pair
             match index_key {
@@ -245,6 +152,103 @@ impl<'gc> RawTable<'gc> {
                 _ => set_reserved_value(&mut self.map, hash, table_key, value),
             }
         })
+    }
+
+    fn grow(&mut self, index_key: Option<usize>) {
+        // If a new element does not fit in either the array or map part of the table, we need
+        // to grow. First, we find the total count of array candidate elements across the array
+        // part, the map part, and the newly inserted key.
+
+        const USIZE_BITS: usize = mem::size_of::<usize>() * 8;
+
+        // Count of array-candidate elements based on the highest bit in the index
+        let mut array_counts = [0; USIZE_BITS];
+        // Total count of all array-candidate elements
+        let mut array_total = 0;
+
+        for (i, e) in self.array.iter().enumerate() {
+            if !e.is_nil() {
+                array_counts[highest_bit(i)] += 1;
+                array_total += 1;
+            }
+        }
+
+        for (&key, &value) in &self.map {
+            if !value.is_nil() {
+                if let Some(i) = to_array_index(
+                    key.live_key()
+                        .expect("dead keys must have Nil values")
+                        .to_value(),
+                ) {
+                    array_counts[highest_bit(i)] += 1;
+                    array_total += 1;
+                }
+            }
+        }
+
+        if let Some(i) = index_key {
+            array_counts[highest_bit(i)] += 1;
+            array_total += 1;
+        }
+
+        // Then, we compute the new optimal size for the array by finding the largest array size
+        // such that at least half of the elements in the array would be in use.
+
+        let mut optimal_size = 0;
+        let mut total = 0;
+        for i in 0..USIZE_BITS {
+            if (1 << i) / 2 >= array_total {
+                break;
+            }
+
+            if array_counts[i] > 0 {
+                total += array_counts[i];
+                if total > (1 << i) / 2 {
+                    optimal_size = 1 << i;
+                }
+            }
+        }
+
+        let old_array_size = self.array.len();
+        let old_map_size = self.map.len();
+        if optimal_size > old_array_size {
+            // If we're growing the array part, we need to grow the array and take any newly
+            // valid array keys from the map part.
+
+            self.array.reserve(optimal_size - old_array_size);
+            let capacity = self.array.capacity();
+            self.array.resize(capacity, Value::Nil);
+
+            let array = &mut self.array;
+            self.map.retain(|k, v| {
+                if v.is_nil() {
+                    // If our entry is dead, remove it.
+                    return false;
+                }
+
+                let key = k.live_key().expect("all dead keys should have a Nil value");
+
+                // If our live key is an array index that fits in the array portion,
+                // move the entry to the array portion.
+                if let Some(i) = to_array_index(key.to_value()) {
+                    if i < array.len() {
+                        array[i] = *v;
+                        return false;
+                    }
+                }
+
+                true
+            });
+        } else {
+            // If we aren't growing the array, we're adding a new element to the map that won't
+            // fit in the advertised capacity. We explicitly double the map size here.
+            self.map.raw_table_mut().reserve(old_map_size, |(key, _)| {
+                self.hash_builder.hash_one(
+                    key.live_key()
+                        .expect("all keys must be live when table is grown"),
+                )
+            });
+        }
     }
 
     pub fn length(&self) -> i64 {
@@ -386,9 +390,16 @@ impl<'gc> RawTable<'gc> {
         NextValue::NotFound
     }
 
-    // Returns the removed key, if any, and the result of length()
-    //
-    // `key` is 1-indexed.
+    /// Try to efficiently remove a key from the array part of the
+    /// table.  (`key` is one-indexed; if it is None, the length of
+    /// the array is used instead.)
+    ///
+    /// If successful, returns the removed value; otherwise, indicates
+    /// whether the operation is possible to implement with a fallback,
+    /// or is impossible due to an out-of-range index.
+    ///
+    /// Additionally, always returns the computed length of the array
+    /// from before the operation.
     pub fn array_remove_shift(
         &mut self,
         key: Option<i64>,
@@ -429,9 +440,17 @@ impl<'gc> RawTable<'gc> {
         RawArrayOpResult::Success(value)
     }
 
-    // Returns whether the insert succeeded, and the result of length()
-    //
-    // `key` is 1-indexed.
+    /// Try to efficiently insert a key and value into the array part
+    /// of the table.  (`key` is one-indexed; if it is `None`, the
+    /// length of the array is used instead.)
+    ///
+    /// The returned [`RawArrayOpResult`] indicates whether the
+    /// operation was successful, or if it failed,
+    /// whether the operation is possible to implement with a fallback,
+    /// or is impossible due to an out-of-range index.
+    ///
+    /// Additionally, always returns the computed length of the array
+    /// from before the operation.
     pub fn array_insert_shift(
         &mut self,
         key: Option<i64>,
@@ -461,33 +480,24 @@ impl<'gc> RawTable<'gc> {
             return RawArrayOpResult::Possible;
         }
 
-        match index.cmp(&length) {
-            Ordering::Greater => unreachable!(),
-            Ordering::Equal => {
-                // Length guarantees that (0-inx) arr[length] == nil,
-                // so it shouldn't be in the map. (TODO: check; dead keys?)
-                if index == self.array.len() {
-                    // TODO: move array growing logic out of set
-                    self.array.push(value);
-                } else {
-                    self.array[length] = value;
-                }
-                RawArrayOpResult::Success(())
-            }
-            Ordering::Less => {
-                // Length guarantees that (0-inx) arr[length] == nil,
-                // so it shouldn't be in the map. (TODO: check; dead keys?)
-                if length == self.array.len() {
-                    // TODO: move array growing logic out of set
-                    self.array.push(value); // Make rotate do the work for us
-                    self.array[index..=length].rotate_right(1);
-                } else {
-                    self.array[index] = value;
-                    self.array[index..=length].rotate_right(1);
-                }
-                RawArrayOpResult::Success(())
+        assert!(index <= length);
+
+        if length == self.array.len() {
+            // If the array is full, try to grow it.
+            self.grow(Some(index));
+            if length >= self.array.len() {
+                // If resize didn't grow the array, use fallback impl
+                return RawArrayOpResult::Possible;
             }
         }
+
+        // We know here that length < array.len(), so we shift each
+        // element to the right by one.
+        // array[length] == nil, which gets rotated back to array[index];
+        // we replace it with the value to insert.
+        self.array[index..=length].rotate_right(1);
+        self.array[index] = value;
+        RawArrayOpResult::Success(())
     }
 
     pub fn reserve_array(&mut self, additional: usize) {

--- a/src/thread/thread.rs
+++ b/src/thread/thread.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 
 use crate::{
     closure::{UpValue, UpValueState},
+    fuel::count_fuel,
     meta_ops,
     types::{RegisterIndex, VarCount},
     BoxSequence, Callback, Closure, Context, Error, FromMultiValue, Fuel, Function, IntoMultiValue,
@@ -1008,12 +1009,6 @@ impl<'gc, 'a> LuaRegisters<'gc, 'a> {
 
         self.open_upvalues.truncate(start);
     }
-}
-
-fn count_fuel(per_item: i32, len: usize) -> i32 {
-    i32::try_from(len)
-        .unwrap_or(i32::MAX)
-        .saturating_mul(per_item)
 }
 
 fn open_upvalue_ind<'gc>(u: UpValue<'gc>) -> usize {


### PR DESCRIPTION
- Implement `table.insert` and `table.remove`, supporting metamethods
- For plain tables (no index/newindex/len metamethods), optimize inserts and removes that work entirely within the array portion of the table; this is the normal use-case of `table.insert` and `table.remove`, so it should be worth the minor added complexity.

This now includes a reasonable set of tests, though the edge cases of the optimized case may be difficult to trigger explicitly.