### PR TITLE
Implement `__concat`, `table.concat`, and add Lua polyfills for `table.sort` and `table.move`

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -134,12 +134,12 @@ likely not be implemented due to differences between piccolo and PUC-Lua.
 
 | Status | Function                     | Differences | Notes |
 | ------ | ---------------------------- | ----------- | ----- |
-| 🔵     | `concat(list[, sep, i, j])`  |             |       |
+| 🔵     | `concat(list[, sep, i, j])`  |             | Supports the `__concat` metamethod |
 | 🔵     | `insert(list, [pos,] value)` |             |       |
 | 🔵     | `move(a1, f, e, t[, a2])`    |             | Currently implemented with a Lua polyfill |
 | 🔵     | `pack(args...)`              |             |       |
 | 🔵     | `remove(list[, pos])`        |             |       |
-| 🔵     | `sort(list[, comp])`         |             | Currently implemented with a Lua polyfill using a simple merge sort, rather than Lua's quicksort impl |
+| 🔵     | `sort(list[, comp])`         |             | Currently implemented with a Lua polyfill using a simple merge sort, rather than PUC-Rio Lua's quicksort impl |
 | 🔵     | `unpack(list[, i, j])`       |             |       |
 
 ## Math

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -134,12 +134,12 @@ likely not be implemented due to differences between piccolo and PUC-Lua.
 
 | Status | Function                     | Differences | Notes |
 | ------ | ---------------------------- | ----------- | ----- |
-| ⚫️️   | `concat(list[, sep, i, j])`  |             |       |
-| ⚫️️   | `insert(list, [pos,] value)` |             |       |
-| ⚫️️   | `move(a1, f, e, t[, a2])`    |             |       |
+| 🔵     | `concat(list[, sep, i, j])`  |             |       |
+| 🔵     | `insert(list, [pos,] value)` |             |       |
+| 🔵     | `move(a1, f, e, t[, a2])`    |             | Currently implemented with a Lua polyfill |
 | 🔵     | `pack(args...)`              |             |       |
-| ⚫️️   | `remove(list[, pos])`        |             |       |
-| ⚫️️   | `sort(list[, comp])`         |             |       |
+| 🔵     | `remove(list[, pos])`        |             |       |
+| 🔵     | `sort(list[, comp])`         |             | Currently implemented with a Lua polyfill using a simple merge sort, rather than Lua's quicksort impl |
 | 🔵     | `unpack(list[, i, j])`       |             |       |
 
 ## Math

--- a/src/async_callback.rs
+++ b/src/async_callback.rs
@@ -12,6 +12,7 @@ use std::{
 use gc_arena::{Collect, DynamicRootSet, Mutation};
 
 use crate::{
+    meta_ops::{MetaCall, MetaResult},
     stash::{Fetchable, Stashable},
     BoxSequence, Context, Error, Execution, Function, Sequence, SequencePoll, Stack, StashedError,
     StashedFunction, StashedThread, Thread,
@@ -316,6 +317,55 @@ impl<'gc, 'a> Locals<'gc, 'a> {
     /// [`Locals::stash`].
     pub fn fetch<F: Fetchable>(&self, local: &F) -> F::Fetched<'gc> {
         local.fetch(self.roots)
+    }
+}
+
+#[must_use]
+pub struct PreparedCall {
+    func: Option<crate::StashedFunction>,
+    bottom: usize,
+    returns: usize,
+}
+
+impl PreparedCall {
+    pub async fn execute(self, seq: &mut AsyncSequence) -> Result<(), crate::StashedError> {
+        if let Some(func) = self.func {
+            seq.call(&func, self.bottom).await?;
+        }
+        seq.enter(|_, _, _, mut stack| {
+            stack.resize(self.bottom + self.returns);
+        });
+        Ok(())
+    }
+}
+
+pub fn prepare_async_metaop<'gc, const N: usize>(
+    ctx: Context<'gc>,
+    stack: &mut Stack<'gc, '_>,
+    locals: Locals<'gc, '_>,
+    bottom: usize,
+    call: MetaResult<'gc, N>,
+    returns: usize,
+) -> PreparedCall {
+    match call {
+        MetaResult::Value(v) => {
+            stack.resize(bottom);
+            stack.push_back(v);
+            PreparedCall {
+                func: None,
+                bottom,
+                returns,
+            }
+        }
+        MetaResult::Call(MetaCall { function, args }) => {
+            stack.resize(bottom);
+            stack.extend(args);
+            PreparedCall {
+                func: Some(locals.stash(&ctx, function)),
+                bottom,
+                returns,
+            }
+        }
     }
 }
 

--- a/src/meta_ops.rs
+++ b/src/meta_ops.rs
@@ -4,10 +4,9 @@ use gc_arena::Collect;
 use thiserror::Error;
 
 use crate::async_callback::prepare_async_metaop;
-use crate::{async_sequence, Execution, SequenceReturn, Stack};
+use crate::{async_sequence, SequenceReturn};
 use crate::{
-    table::InvalidTableKey, Callback, CallbackReturn, Context, Error, Function, IntoValue, Table,
-    Value,
+    table::InvalidTableKey, Callback, CallbackReturn, Context, Function, IntoValue, Table, Value,
 };
 
 /// An enum of every possible Lua metamethod.

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -73,6 +73,15 @@ impl<'gc, 'a> Stack<'gc, 'a> {
         }
     }
 
+    pub fn remove(&mut self, i: usize) -> Option<Value<'gc>> {
+        let index = self.bottom + i;
+        if index < self.values.len() {
+            Some(self.values.remove(index))
+        } else {
+            None
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.values.len() - self.bottom
     }

--- a/src/stdlib/table.rs
+++ b/src/stdlib/table.rs
@@ -9,9 +9,9 @@ use crate::{
     fuel::count_fuel,
     meta_ops::{self, MetaResult},
     table::RawTable,
-    BoxSequence, Callback, CallbackReturn, Context, Error, Execution, IntoValue, MetaMethod,
-    Sequence, SequencePoll, SequenceReturn, Stack, StashedError, StashedFunction, StashedTable,
-    StashedValue, Table, Value,
+    BoxSequence, Callback, CallbackReturn, Closure, Context, Error, Execution, IntoValue,
+    MetaMethod, Sequence, SequencePoll, SequenceReturn, Stack, StashedError, StashedFunction,
+    StashedTable, StashedValue, Table, Value,
 };
 
 pub fn load_table<'gc>(ctx: Context<'gc>) {
@@ -65,6 +65,10 @@ pub fn load_table<'gc>(ctx: Context<'gc>) {
     table.set_field(ctx, "remove", Callback::from_fn(&ctx, table_remove_impl));
 
     table.set_field(ctx, "insert", Callback::from_fn(&ctx, table_insert_impl));
+
+    let data = include_str!("table/sort.lua");
+    let sort = Closure::load(ctx, Some("table/sort.lua"), data.as_bytes()).unwrap();
+    table.set_field(ctx, "sort", sort);
 
     ctx.set_global("table", table);
 }

--- a/src/stdlib/table.rs
+++ b/src/stdlib/table.rs
@@ -84,8 +84,12 @@ pub fn load_table<'gc>(ctx: Context<'gc>) {
     table.set_field(ctx, "insert", Callback::from_fn(&ctx, table_insert_impl));
 
     let data = include_str!("table/sort.lua");
-    let sort = Closure::load(ctx, Some("table/sort.lua"), data.as_bytes()).unwrap();
-    table.set_field(ctx, "sort", sort);
+    let func = Closure::load(ctx, Some("table/sort.lua"), data.as_bytes()).unwrap();
+    table.set_field(ctx, "sort", func);
+
+    let data = include_str!("table/move.lua");
+    let func = Closure::load(ctx, Some("table/move.lua"), data.as_bytes()).unwrap();
+    table.set_field(ctx, "move", func);
 
     ctx.set_global("table", table);
 }

--- a/src/stdlib/table/move.lua
+++ b/src/stdlib/table/move.lua
@@ -1,0 +1,72 @@
+
+-- A basic implementation of table.move, directly ported from
+-- PUC-Rio Lua's ltablib.c.  The original file's license is included
+-- here:
+
+--[[
+/******************************************************************************
+* Copyright (C) 1994-2024 Lua.org, PUC-Rio.
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+******************************************************************************/
+]]
+
+src, src_base, end_idx, dst_base, dst = ...
+
+if dst == nil then
+    dst = src
+end
+
+src_base = math.tointeger(src_base)
+end_idx = math.tointeger(end_idx)
+dst_base = math.tointeger(dst_base)
+
+if src_base == nil or end_idx == nil or dst_base == nil then
+    error("arguments to move must be integers")
+end
+if type(src) ~= "table" or type(dst) ~= "table" then
+    error("arguments to move must be tables")
+end
+
+if end_idx < src_base then
+    return dst
+end
+
+if src_base <= 0 and end_idx >= math.maxinteger + src_base then
+    error("too many elements to move") -- n would overflow
+end
+
+local n = end_idx - src_base + 1   -- number of elements to move
+
+if dst_base > math.maxinteger - n + 1 then
+    error("destination wrap around")
+end
+
+if dst_base > end_idx or dst_base <= src_base or dst ~= src then
+    for i = 0, n - 1 do
+        dst[dst_base + i] = src[src_base + i]
+    end
+else
+    for i = n - 1, 0, -1 do
+        dst[dst_base + i] = src[src_base + i]
+    end
+end
+
+return dst

--- a/src/stdlib/table/sort.lua
+++ b/src/stdlib/table/sort.lua
@@ -16,24 +16,46 @@ local function merge(src, dst, lo, mid, hi)
     end
 end
 
+-- merge, but uses the given comparison function
+local function merge_cmp(src, dst, lo, mid, hi, cmp)
+    local i = lo
+    local j = mid
+    for k = lo, hi do
+        if i < mid and (j > hi or cmp(src[i], src[j])) then
+            dst[k] = src[i]
+            i = i + 1
+        else
+            dst[k] = src[j]
+            j = j + 1
+        end
+    end
+end
+
 -- sorts arr[lo ..= hi] (inclusive, one-indexed)
-local function sort(arr, lo, hi, t)
+local function sort(arr, lo, hi, t, cmp)
     local n = hi - (lo - 1)
     if n <= 1 then
         return
     end
     local mid = lo + n // 2
-    sort(arr, lo, mid - 1, t)
-    sort(arr, mid, hi, t)
+    sort(arr, lo, mid - 1, t, cmp)
+    sort(arr, mid, hi, t, cmp)
     for i = lo, hi do
         t[i] = arr[i]
     end
-    merge(t, arr, lo, mid, hi)
+    if cmp == nil then
+        merge(t, arr, lo, mid, hi)
+    else
+        merge_cmp(t, arr, lo, mid, hi, cmp)
+    end
 end
 
-local arr = ...
+local arr, cmp = ...
 local len = #arr
+if len < 0 then
+    len = 0
+end
 
 local temp = {}
-sort(arr, 1, len, temp)
+sort(arr, 1, len, temp, cmp)
 return

--- a/src/stdlib/table/sort.lua
+++ b/src/stdlib/table/sort.lua
@@ -1,0 +1,39 @@
+
+-- a basic merge sort implementation
+
+-- merges src[lo..mid] and src[mid..=hi] into dst[lo..=hi]
+local function merge(src, dst, lo, mid, hi)
+    local i = lo
+    local j = mid
+    for k = lo, hi do
+        if i < mid and (j > hi or src[i] < src[j]) then
+            dst[k] = src[i]
+            i = i + 1
+        else
+            dst[k] = src[j]
+            j = j + 1
+        end
+    end
+end
+
+-- sorts arr[lo ..= hi] (inclusive, one-indexed)
+local function sort(arr, lo, hi, t)
+    local n = hi - (lo - 1)
+    if n <= 1 then
+        return
+    end
+    local mid = lo + n // 2
+    sort(arr, lo, mid - 1, t)
+    sort(arr, mid, hi, t)
+    for i = lo, hi do
+        t[i] = arr[i]
+    end
+    merge(t, arr, lo, mid, hi)
+end
+
+local arr = ...
+local len = #arr
+
+local temp = {}
+sort(arr, 1, len, temp)
+return

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -4,10 +4,7 @@ mod vm;
 
 use thiserror::Error;
 
-use crate::{
-    meta_ops::{MetaCallError, MetaOperatorError},
-    string::BadConcatType,
-};
+use crate::meta_ops::{MetaCallError, MetaOperatorError};
 
 pub use self::{
     executor::{
@@ -31,8 +28,6 @@ pub enum VMError {
     BadCall(#[from] MetaCallError),
     #[error("operator error")]
     OperatorError(#[from] MetaOperatorError),
-    #[error("bad concat type")]
-    BadConcatType(#[from] BadConcatType),
     #[error("_ENV upvalue is only allowed on top-level closure")]
     BadEnvUpValue,
     #[error("Invalid types in for loop; expected numbers, found {0}, {1}, and {2}")]

--- a/src/thread/vm.rs
+++ b/src/thread/vm.rs
@@ -358,15 +358,16 @@ pub(super) fn run_vm<'gc>(
                 source,
                 count,
             } => {
-                let values =
-                    &registers.stack_frame[source.0 as usize..source.0 as usize + count as usize];
-                match meta_ops::concat(ctx, values)? {
+                let base = source.0 as usize;
+                let values = &registers.stack_frame[base..base + count as usize];
+                match meta_ops::concat_many(ctx, values)? {
                     ConcatMetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
-                    ConcatMetaResult::Call(call) => {
-                        lua_frame.call_meta_function(
+                    ConcatMetaResult::Call(func) => {
+                        lua_frame.call_meta_function_in_place(
                             ctx,
-                            call.function,
-                            &call.args,
+                            func,
+                            base,
+                            count,
                             MetaReturn::Register(dest),
                         )?;
                         break;

--- a/src/thread/vm.rs
+++ b/src/thread/vm.rs
@@ -2,7 +2,7 @@ use allocator_api2::vec;
 use gc_arena::allocator_api::MetricsAlloc;
 
 use crate::{
-    meta_ops::{self, MetaResult},
+    meta_ops::{self, ConcatMetaResult, MetaResult},
     opcode::{Operation, RCIndex},
     table::RawTable,
     thread::thread::MetaReturn,
@@ -358,10 +358,20 @@ pub(super) fn run_vm<'gc>(
                 source,
                 count,
             } => {
-                registers.stack_frame[dest.0 as usize] = Value::String(String::concat(
-                    ctx,
-                    &registers.stack_frame[source.0 as usize..source.0 as usize + count as usize],
-                )?);
+                let values =
+                    &registers.stack_frame[source.0 as usize..source.0 as usize + count as usize];
+                match meta_ops::concat(ctx, values)? {
+                    ConcatMetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
+                    ConcatMetaResult::Call(call) => {
+                        lua_frame.call_meta_function(
+                            ctx,
+                            call.function,
+                            &call.args,
+                            MetaReturn::Register(dest),
+                        )?;
+                        break;
+                    }
+                }
             }
 
             Operation::GetUpValue { source, dest } => {

--- a/tests/scripts/concat.lua
+++ b/tests/scripts/concat.lua
@@ -1,5 +1,19 @@
 
 do
+    local i = 0
+    local t = setmetatable({}, {
+        __concat = function(a, b) i = i + 1 return i .. "(" .. tostring(a) .. tostring(b) .. ")" end,
+        __tostring = function(this) i = i + 1 return i end
+    })
+
+    assert(t..t..t..t == "6(74(51(23)))")
+end
+
+do
+    assert("a".."b".."c" == "abc")
+end
+
+do
     local t = { "a", "b", "c" }
     assert(table.concat(t) == "abc")
     assert(table.concat(t, ",") == "a,b,c")
@@ -18,8 +32,8 @@ do
 end
 
 do
-    assert(not pcall(function() table.concat({ true }) end))
-    assert(not pcall(function() table.concat({ {} }) end))
+    assert(not pcall(function() table.concat({ "a", true }) end))
+    assert(not pcall(function() table.concat({ "b", {} }) end))
 
     local t = setmetatable({ "a" }, { __len = function() return 2 end })
     assert(not pcall(function() table.concat(t) end))

--- a/tests/scripts/metaops.lua
+++ b/tests/scripts/metaops.lua
@@ -127,12 +127,13 @@ do
     cursed_mt["__index"] = function(a, b) return setmetatable({ "index", a, b }, cursed_mt) end
     cursed_mt["__call"] = function(this, ...) return setmetatable({ "call", this, ... }, cursed_mt) end
 
+    cursed_mt["__concat"] = function(a, b) return setmetatable({ "concat", a, b }, cursed_mt) end
+
     -- Not tested here:
     -- cursed_mt["__newindex"] = function(a, b) end
     -- cursed_mt["__eq"] = function(a, b) return false end
     -- cursed_mt["__lt"] = function(a, b) return false end
     -- cursed_mt["__le"] = function(a, b) return false end
-    -- cursed_mt["__concat"] = function(a, b) return setmetatable({ "concat", a, b }, cursed_mt) end
 
     local function curse(val)
         return setmetatable(val, cursed_mt)
@@ -140,6 +141,7 @@ do
 
     local a = curse { "a" }
     local b = curse { "b" }
+    local c = curse { "c" }
 
     assert(cmp_array_recurse(a + b, { "add", { "a" }, { "b" } }))
     assert(cmp_array_recurse(a - b, { "sub", { "a" }, { "b" } }))
@@ -162,6 +164,23 @@ do
     assert(cmp_array_recurse(a.b, { "index", { "a" }, "b" }))
     assert(cmp_array_recurse(a(), { "call", { "a" } }))
     assert(cmp_array_recurse(a(1, 2, 3), { "call", { "a" }, 1, 2, 3 }))
+
+
+    assert(cmp_array_recurse(a..b..c, { "concat", { "a" }, { "concat", { "b" }, { "c" } } }))
+    assert(cmp_array_recurse((a..b)..c, { "concat", { "concat", { "a" }, { "b" } }, { "c" } }))
+
+    if string.sub(_VERSION, 1, 7) == "piccolo" then
+        assert(cmp_array_recurse(
+            table.concat({ a, b, c }),
+            { "concat", { "a" }, { "concat", { "b" }, { "c" } } }
+        ))
+
+        local sep = curse { "!" }
+        assert(cmp_array_recurse(
+            table.concat({ a, b, c }, sep),
+            { "concat", { "a" }, { "concat", { "!" }, { "concat", { "b" }, { "concat", { "!" }, { "c" } } } } }
+        ))
+    end
 
 end
 

--- a/tests/scripts/sort.lua
+++ b/tests/scripts/sort.lua
@@ -1,0 +1,29 @@
+
+function is_sorted(list)
+    for i = 2, #list do
+        if list[i - 1] > list[i] then
+            return false
+        end
+    end
+    return true
+end
+
+do
+    local t = { }
+    table.sort(t)
+    assert(#t == 0)
+
+    t = { 4, 9, 3, 1 }
+    table.sort(t)
+    assert(#t == 4 and is_sorted(t))
+end
+
+do
+    local list = {}
+    for i = 1, 100 do
+        table.insert(list, math.random())
+    end
+
+    table.sort(list)
+    assert(#list == 100 and is_sorted(list))
+end

--- a/tests/scripts/table_concat.lua
+++ b/tests/scripts/table_concat.lua
@@ -1,0 +1,40 @@
+
+do
+    local t = { "a", "b", "c" }
+    assert(table.concat(t) == "abc")
+    assert(table.concat(t, ",") == "a,b,c")
+end
+
+do
+    local t = { }
+    assert(table.concat(t) == "")
+    assert(table.concat(t, ",") == "")
+end
+
+do
+    local t = { "a", 2, 3.14 }
+    assert(table.concat(t) == "a23.14")
+    assert(table.concat(t, ",") == "a,2,3.14")
+end
+
+do
+    assert(not pcall(function() table.concat({ true }) end))
+    assert(not pcall(function() table.concat({ {} }) end))
+
+    local t = setmetatable({ "a" }, { __len = function() return 2 end })
+    assert(not pcall(function() table.concat(t) end))
+end
+
+do
+    local az = "abcdefghijklmnopqrstuvwxyz"
+    local t = {}
+    for i = 1, #az do
+        table.insert(t, string.sub(az, i, i))
+    end
+
+    assert(table.concat(t, nil, 24) == "xyz")
+    assert(table.concat(t, nil, 3, 5) == "cde")
+
+    assert(table.concat(t, "", 1, #t) == "abcdefghijklmnopqrstuvwxyz")
+    assert(table.concat(t, "!", 1, #t) == "a!b!c!d!e!f!g!h!i!j!k!l!m!n!o!p!q!r!s!t!u!v!w!x!y!z")
+end

--- a/tests/scripts/table_move.lua
+++ b/tests/scripts/table_move.lua
@@ -1,0 +1,64 @@
+
+local function arrays_eq(a, b)
+    for k, v in pairs(a) do
+        if b[k] ~= v then return false end
+    end
+    for k, v in pairs(b) do
+        if a[k] ~= v then return false end
+    end
+    return true
+end
+
+do
+    local t = { 1, 2, 3 }
+    table.move(t, 1, 3, 4)
+    assert(arrays_eq(t, { 1, 2, 3, 1, 2, 3 }))
+
+    t = { 1, 2, 3 }
+    table.move(t, 1, 3, 1)
+    assert(arrays_eq(t, { 1, 2, 3 }))
+
+    table.move(t, 2, 3, 2)
+    assert(arrays_eq(t, { 1, 2, 3 }))
+
+    table.move(t, 2, 3, 1)
+    assert(arrays_eq(t, { 2, 3, 3 }))
+
+    table.move(t, 1, 1, 3)
+    assert(arrays_eq(t, { 2, 3, 2 }))
+end
+
+do
+    local t
+
+    -- forward overlapping copy
+    t = { 1, 2, 3, 4, 5 }
+    table.move(t, 1, 5, 3)
+    assert(arrays_eq(t, { 1, 2, 1, 2, 3, 4, 5 }))
+
+    -- backward overlapping copy
+    t = { 1, 2, 3, 4, 5 }
+    table.move(t, 3, 5, 1)
+    assert(arrays_eq(t, { 3, 4, 5, 4, 5 }))
+
+    t = { 1, 2, 3, 4, 5 }
+    table.move(t, 1, 5, 3, t) -- with explicit dest of self
+    assert(arrays_eq(t, { 1, 2, 1, 2, 3, 4, 5 }))
+
+    t = { 1, 2, 3, 4, 5 }
+    table.move(t, 3, 5, 1, t) -- with explicit dest of self
+    assert(arrays_eq(t, { 3, 4, 5, 4, 5 }))
+end
+
+do
+    local a = { 1, 2, 3 }
+    local b = {}
+
+    table.move(a, 1, 3, 2, b)
+    assert(arrays_eq(b, { nil, 1, 2, 3 }))
+    assert(arrays_eq(a, { 1, 2, 3 }))
+
+    b = {}
+    table.move(a, 1, 3, -1, b)
+    assert(arrays_eq(b, { [-1] = 1, [0] = 2, 3 }))
+end


### PR DESCRIPTION
At some point it would be good to have `table.move` and `table.sort` implemented in Rust, but for now a Lua implementation works.

This PR also implements the `__concat` metamethod, and uses it to implement `table.concat`; unlike PRLua's implementation, this version supports tables with the `__concat` metamethod.

For example, `table.concat({ a, b, c }, sep)` is equivalent to `a .. sep .. b .. sep .. c`, and respects the right-associativity of the `..` operator.

Semantics questions on `table.concat`:
- Should `table.concat({ x }) == x`, regardless of type?  It currently does, as it never tries to call the `__concat` metaoperator.
- Is the complexity of this worth it over only supporting string/integers in `table.concat`?