### PR TITLE
Fix panic in concat with negative integers

### DIFF
--- a/src/meta_ops.rs
+++ b/src/meta_ops.rs
@@ -784,7 +784,7 @@ fn estimate_concatenated_len<'gc>(
     let mut len = 0usize;
     for value in values {
         let value_len = match value {
-            Value::Integer(i) => i.ilog10() as usize + i.is_negative() as usize,
+            Value::Integer(i) => i.abs().max(1).ilog10() as usize + i.is_negative() as usize,
             Value::Number(_n) => 10,
             Value::String(s) => s.as_bytes().len(),
             _ => return Ok(None),

--- a/tests/scripts/concat.lua
+++ b/tests/scripts/concat.lua
@@ -52,3 +52,12 @@ do
     assert(table.concat(t, "", 1, #t) == "abcdefghijklmnopqrstuvwxyz")
     assert(table.concat(t, "!", 1, #t) == "a!b!c!d!e!f!g!h!i!j!k!l!m!n!o!p!q!r!s!t!u!v!w!x!y!z")
 end
+
+do
+    assert(0 .. 1 .. -1 == "01-1")
+
+    assert(-0.1 .. 0.1 == "-0.10.1")
+
+    -- Formatting of floats differs slightly from PRLua
+    -- assert(0.1 .. 0.0 .. -0.0 .. -0.1 == "0.10.0-0.0-0.1")
+end


### PR DESCRIPTION
Currently string concatenation panics when used with integers ≤ 0 due to a bug in my use of ilog10.  This PR fixes that bug and adds a test for it.

Example case that triggers the bug:
```lua
local i = 0
local test = "Hello, World!" .. i
```
