### PR TITLE
Fix estimate_concatenated_len for non-positive integers.

### DIFF
--- a/src/meta_ops.rs
+++ b/src/meta_ops.rs
@@ -784,7 +784,7 @@ fn estimate_concatenated_len<'gc>(
     let mut len = 0usize;
     for value in values {
         let value_len = match value {
-            Value::Integer(i) => i.ilog10() as usize + i.is_negative() as usize,
+            Value::Integer(i) => i.abs().ilog10() as usize + i.is_negative() as usize,
             Value::Number(_n) => 10,
             Value::String(s) => s.as_bytes().len(),
             _ => return Ok(None),

--- a/src/meta_ops.rs
+++ b/src/meta_ops.rs
@@ -784,7 +784,8 @@ fn estimate_concatenated_len<'gc>(
     let mut len = 0usize;
     for value in values {
         let value_len = match value {
-            Value::Integer(i) => i.abs().ilog10() as usize + i.is_negative() as usize,
+            // ilog10 panics for values <= 0
+            Value::Integer(i) => i.abs().max(1).ilog10() as usize + i.is_negative() as usize,
             Value::Number(_n) => 10,
             Value::String(s) => s.as_bytes().len(),
             _ => return Ok(None),


### PR DESCRIPTION
The `estimate_concatenated_len` calculates a ilog10 if the value is integer. The method panics for non-positive values:
https://doc.rust-lang.org/std/primitive.i64.html#method.ilog10