### PR TITLE
Rust version bump in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.77.2
+      - image: cimg/rust:1.81
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Fixes CI: `error: package `home v0.5.11` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.77.2`