### PR TITLE
Refactor math library for #![no_std] support, support parsing subnormal hexfloats

### DIFF
--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -1,120 +1,89 @@
-use std::{cell::RefCell, f64, rc::Rc};
-
 use gc_arena::Mutation;
-use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 use crate::{
     async_sequence, meta_ops, Callback, CallbackReturn, Context, FromMultiValue, IntoMultiValue,
     IntoValue, SequenceReturn, Table, Value,
 };
 
-pub fn load_math<'gc>(ctx: Context<'gc>) {
-    fn callback<'gc, F, A, R>(name: &'static str, mc: &Mutation<'gc>, f: F) -> Callback<'gc>
-    where
-        F: Fn(Context<'gc>, A) -> Option<R> + 'static,
-        A: FromMultiValue<'gc>,
-        R: IntoMultiValue<'gc>,
-    {
-        Callback::from_fn(mc, move |ctx, _, mut stack| {
-            if let Some(res) = f(ctx, stack.consume(ctx)?) {
-                stack.replace(ctx, res);
-                Ok(CallbackReturn::Return)
-            } else {
-                Err(format!("Bad argument to {name}").into_value(ctx).into())
-            }
-        })
-    }
-
-    fn to_int(v: Value) -> Value {
-        if let Some(i) = v.to_integer() {
-            Value::Integer(i)
+fn callback<'gc, F, A, R>(name: &'static str, mc: &Mutation<'gc>, f: F) -> Callback<'gc>
+where
+    F: Fn(Context<'gc>, A) -> Option<R> + 'static,
+    A: FromMultiValue<'gc>,
+    R: IntoMultiValue<'gc>,
+{
+    Callback::from_fn(mc, move |ctx, _, mut stack| {
+        if let Some(res) = f(ctx, stack.consume(ctx)?) {
+            stack.replace(ctx, res);
+            Ok(CallbackReturn::Return)
         } else {
-            v
+            Err(format!("Bad argument to {name}").into_value(ctx).into())
         }
-    }
+    })
+}
 
+pub fn load_math<'gc>(ctx: Context<'gc>) {
     let math = Table::new(&ctx);
-    let seeded_rng: Rc<RefCell<SmallRng>> = Rc::new(RefCell::new(SmallRng::from_entropy()));
 
+    load_baseline(ctx, math);
+    load_cmp(ctx, math);
+
+    load_random(ctx, math);
+
+    load_trig(ctx, math);
+    load_float(ctx, math);
+
+    ctx.set_global("math", math);
+}
+
+pub fn load_baseline<'gc>(ctx: Context<'gc>, math: Table<'gc>) {
     math.set_field(
         ctx,
         "abs",
         callback("abs", &ctx, |_, v: Value| {
-            Some(if let Value::Integer(i) = v {
-                Value::Integer(i.abs())
+            if let Value::Integer(i) = v {
+                Some(Value::Integer(i.abs()))
             } else {
-                v.to_number()?.abs().into()
-            })
-        }),
-    );
-
-    math.set_field(
-        ctx,
-        "acos",
-        callback("acos", &ctx, |_, v: f64| Some(v.acos())),
-    );
-
-    math.set_field(
-        ctx,
-        "asin",
-        callback("asin", &ctx, |_, v: f64| Some(v.asin())),
-    );
-
-    math.set_field(
-        ctx,
-        "atan",
-        callback("atan", &ctx, |_, (a, b): (f64, Option<f64>)| {
-            Some(if let Some(b) = b {
-                a.atan2(b)
-            } else {
-                a.atan()
-            })
-        }),
-    );
-
-    math.set_field(
-        ctx,
-        "ceil",
-        callback("ceil", &ctx, |_, v: f64| Some(to_int(v.ceil().into()))),
-    );
-
-    math.set_field(ctx, "cos", callback("cos", &ctx, |_, v: f64| Some(v.cos())));
-
-    math.set_field(
-        ctx,
-        "deg",
-        callback("deg", &ctx, |_, v: f64| Some(v.to_degrees())),
-    );
-
-    math.set_field(
-        ctx,
-        "exp",
-        callback("exp", &ctx, |_, v: f64| Some(f64::consts::E.powf(v))),
-    );
-
-    math.set_field(
-        ctx,
-        "floor",
-        callback("floor", &ctx, |_, v: f64| Some(to_int(v.floor().into()))),
-    );
-
-    math.set_field(
-        ctx,
-        "fmod",
-        callback("fmod", &ctx, |_, (f, g): (f64, f64)| {
-            let result = (f % g).abs();
-            Some(if f < 0.0 { -result } else { result })
+                Some(Value::Number(v.to_number()?.abs()))
+            }
         }),
     );
 
     math.set_field(ctx, "huge", Value::Number(f64::INFINITY));
+    math.set_field(ctx, "maxinteger", Value::Integer(i64::MAX));
+    math.set_field(ctx, "mininteger", Value::Integer(i64::MIN));
+    math.set_field(ctx, "pi", Value::Number(core::f64::consts::PI));
 
     math.set_field(
         ctx,
-        "log",
-        callback("log", &ctx, |_, (v, base): (f64, Option<f64>)| match base {
-            None => Some(v.ln()),
-            Some(base) => Some(v.log(base)),
+        "tointeger",
+        callback("tointeger", &ctx, |_, v: Value| {
+            Some(if let Some(i) = v.to_integer() {
+                i.into()
+            } else {
+                Value::Nil
+            })
+        }),
+    );
+
+    math.set_field(
+        ctx,
+        "type",
+        callback("type", &ctx, |ctx, v: Value| {
+            Some(match v {
+                Value::Integer(_) => "integer".into_value(ctx),
+                Value::Number(_) => "float".into_value(ctx),
+                _ => Value::Nil,
+            })
+        }),
+    );
+}
+
+pub fn load_cmp<'gc>(ctx: Context<'gc>, math: Table<'gc>) {
+    math.set_field(
+        ctx,
+        "ult",
+        callback("ult", &ctx, |_, (a, b): (i64, i64)| {
+            Some(Value::Boolean((a as u64) < (b as u64)))
         }),
     );
 
@@ -215,18 +184,34 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
             Ok(CallbackReturn::Sequence(s))
         }),
     );
+}
 
-    math.set_field(ctx, "maxinteger", Value::Integer(i64::MAX));
-
-    math.set_field(ctx, "mininteger", Value::Integer(i64::MIN));
+pub fn load_float<'gc>(ctx: Context<'gc>, math: Table<'gc>) {
+    fn to_int(v: Value) -> Value {
+        if let Some(i) = v.to_integer() {
+            Value::Integer(i)
+        } else {
+            v
+        }
+    }
 
     math.set_field(
         ctx,
-        "modf",
-        callback("modf", &ctx, |_, f: f64| Some((f as i64, f % 1.0))),
+        "ceil",
+        callback("ceil", &ctx, |_, v: f64| Some(to_int(v.ceil().into()))),
     );
 
-    math.set_field(ctx, "pi", Value::Number(f64::consts::PI));
+    math.set_field(
+        ctx,
+        "floor",
+        callback("floor", &ctx, |_, v: f64| Some(to_int(v.floor().into()))),
+    );
+
+    math.set_field(
+        ctx,
+        "deg",
+        callback("deg", &ctx, |_, v: f64| Some(v.to_degrees())),
+    );
 
     math.set_field(
         ctx,
@@ -234,7 +219,83 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
         callback("rad", &ctx, |_, v: f64| Some(v.to_radians())),
     );
 
-    let random_rng = seeded_rng.clone();
+    math.set_field(
+        ctx,
+        "exp",
+        callback("exp", &ctx, |_, v: f64| Some(f64::exp(v))),
+    );
+
+    math.set_field(
+        ctx,
+        "log",
+        callback("log", &ctx, |_, (v, base): (f64, Option<f64>)| match base {
+            None => Some(v.ln()),
+            Some(base) => Some(v.log(base)),
+        }),
+    );
+
+    math.set_field(
+        ctx,
+        "sqrt",
+        callback("sqrt", &ctx, |_, v: f64| Some(v.sqrt())),
+    );
+
+    math.set_field(
+        ctx,
+        "fmod",
+        callback("fmod", &ctx, |_, (f, g): (f64, f64)| {
+            let result = (f % g).abs();
+            Some(if f < 0.0 { -result } else { result })
+        }),
+    );
+
+    math.set_field(
+        ctx,
+        "modf",
+        callback("modf", &ctx, |_, f: f64| Some((f as i64, f % 1.0))),
+    );
+}
+
+pub fn load_trig<'gc>(ctx: Context<'gc>, math: Table<'gc>) {
+    math.set_field(
+        ctx,
+        "acos",
+        callback("acos", &ctx, |_, v: f64| Some(v.acos())),
+    );
+
+    math.set_field(
+        ctx,
+        "asin",
+        callback("asin", &ctx, |_, v: f64| Some(v.asin())),
+    );
+
+    math.set_field(
+        ctx,
+        "atan",
+        callback("atan", &ctx, |_, (a, b): (f64, Option<f64>)| {
+            Some(if let Some(b) = b {
+                a.atan2(b)
+            } else {
+                a.atan()
+            })
+        }),
+    );
+
+    math.set_field(ctx, "cos", callback("cos", &ctx, |_, v: f64| Some(v.cos())));
+
+    math.set_field(ctx, "sin", callback("sin", &ctx, |_, v: f64| Some(v.sin())));
+
+    math.set_field(ctx, "tan", callback("tan", &ctx, |_, v: f64| Some(v.tan())));
+}
+
+pub fn load_random<'gc>(ctx: Context<'gc>, math: Table<'gc>) {
+    use std::{cell::RefCell, rc::Rc};
+
+    use rand::{rngs::SmallRng, Rng, SeedableRng};
+
+    let seeded_rng = Rc::new(RefCell::new(SmallRng::from_entropy()));
+
+    let random_rng = Rc::clone(&seeded_rng);
     math.set_field(
         ctx,
         "random",
@@ -255,7 +316,7 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
         ),
     );
 
-    let randomseed_rng = seeded_rng.clone();
+    let randomseed_rng = Rc::clone(&seeded_rng);
     math.set_field(
         ctx,
         "randomseed",
@@ -276,7 +337,7 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
                     (Some(high), Some(low)) => {
                         let high_bytes = high.to_ne_bytes();
                         let low_bytes = low.to_ne_bytes();
-                        let seed = std::array::from_fn(|idx| {
+                        let seed: [u8; 32] = core::array::from_fn(|idx| {
                             let idx_mod_16 = idx % 16;
                             if idx_mod_16 >= 8 {
                                 high_bytes[idx_mod_16 - 8]
@@ -292,48 +353,4 @@ pub fn load_math<'gc>(ctx: Context<'gc>) {
             },
         ),
     );
-
-    math.set_field(ctx, "sin", callback("sin", &ctx, |_, v: f64| Some(v.sin())));
-
-    math.set_field(
-        ctx,
-        "sqrt",
-        callback("sqrt", &ctx, |_, v: f64| Some(v.sqrt())),
-    );
-
-    math.set_field(ctx, "tan", callback("tan", &ctx, |_, v: f64| Some(v.tan())));
-
-    math.set_field(
-        ctx,
-        "tointeger",
-        callback("tointeger", &ctx, |_, v: Value| {
-            Some(if let Some(i) = v.to_integer() {
-                i.into()
-            } else {
-                Value::Nil
-            })
-        }),
-    );
-
-    math.set_field(
-        ctx,
-        "type",
-        callback("type", &ctx, |ctx, v: Value| {
-            Some(match v {
-                Value::Integer(_) => "integer".into_value(ctx),
-                Value::Number(_) => "float".into_value(ctx),
-                _ => Value::Nil,
-            })
-        }),
-    );
-
-    math.set_field(
-        ctx,
-        "ult",
-        callback("ult", &ctx, |_, (a, b): (i64, i64)| {
-            Some(Value::Boolean((a as u64) < (b as u64)))
-        }),
-    );
-
-    ctx.set_global("math", math);
 }


### PR DESCRIPTION
This adds an implementation of `ldexp` to more closely match PUC-Rio Lua's hexfloat parsing, which allows us to parse subnormal hexfloats (and is significantly faster than `exp2`).

This also reorganizes the math module to make it easier to selectively disable parts, which will be necessary for supporting `#![no_std]` cleanly, as many float methods only exist in `std`.