### PR TITLE
Remove faulty concat optimization

### DIFF
--- a/src/thread/vm.rs
+++ b/src/thread/vm.rs
@@ -363,11 +363,15 @@ pub(super) fn run_vm<'gc>(
                 match meta_ops::concat_many(ctx, values)? {
                     ConcatMetaResult::Value(v) => registers.stack_frame[dest.0 as usize] = v,
                     ConcatMetaResult::Call(func) => {
-                        lua_frame.call_meta_function_in_place(
+                        // This would be nice to do in-place (without copying params)
+                        // but that turns out to be difficult to do without corrupting
+                        // the stack, and likely isn't worth the complexity for the
+                        // fallback case.
+                        let args = values.to_owned();
+                        lua_frame.call_meta_function(
                             ctx,
                             func,
-                            base,
-                            count,
+                            &args,
                             MetaReturn::Register(dest),
                         )?;
                         break;

--- a/tests/scripts/pcall_concat_err.lua
+++ b/tests/scripts/pcall_concat_err.lua
@@ -1,0 +1,13 @@
+-- This is an odd one; it's a minimal reproduction of a bug
+-- that ends up corrupting the stack when concat returns
+-- an error from its async sequence.
+-- (the locals' register allocations aren't optimized away,
+-- which allows the interpreter to detect the corruption.)
+local a, b, c
+pcall(function() print(""..nil) end)
+
+-- Additional reproduction, without using pcall:
+--[[
+local ts = setmetatable({}, { __concat = function() return "" end})
+_ = (function() print(""..ts) end)()
+]]


### PR DESCRIPTION
**Edit**: This is a more major issue, and the fallback concat metamethod impl can corrupt the Lua stack even when it shouldn't error.  I've changed this PR to fully remove the faulty optimization, since it wasn't worth the complexity and debugging effort.

Currently, if the concat operator has a type error while running in a `pcall` context, it can corrupt the stack above the pcall.
A minimal reproduction is this:
```lua
local a, b, c
pcall(function() print(""..nil) end)
```
Which results in the following panic:
```
thread 'main' panicked at src/stack.rs:27:9:
assertion failed: values.len() >= bottom
stack backtrace:
...
   2: core::panicking::panic
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:145:5
   3: piccolo::stack::Stack::new
             at ./src/stack.rs:27:9
   4: piccolo::thread::executor::Executor::step
             at ./src/thread/executor.rs:369:60
...
```

The bug appears to be in my implementation of `call_meta_function_in_place` from #88, but I haven't been able to find the cause.  For now I've just disabled the in-place arguments optimization, which will make concat less efficient but correct.

(My intuition is that in the case the function errors, it's resetting the stack to the start of the arguments rather than the end; I'm also not sure that the current approach for `call_meta_function_in_place` is correct in the case of compiler optimizations / register allocation changes, as I don't know if the arguments to concat are guaranteed to be at the top of the stack.)