### PR TITLE
Use byte slices instead of impl Read in lexer and parser

### DIFF
--- a/examples/execute.rs
+++ b/examples/execute.rs
@@ -1,10 +1,13 @@
 use std::fs::File;
+use std::io::Read;
 
 use piccolo::{io::buffered_read, Closure, Executor, Lua};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load the Lua file
-    let file = buffered_read(File::open("./examples/execute.lua")?)?;
+    let mut file = buffered_read(File::open("./examples/execute.lua")?)?;
+    let mut source = Vec::new();
+    file.read_to_end(&mut source)?;
 
     // Instantiate the Lua instance
     let mut lua = Lua::full();
@@ -14,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Get the global env
         let env = ctx.globals();
         // Run the lua script in the global context
-        let closure = Closure::load_with_env(ctx, None, file, env)?;
+        let closure = Closure::load_with_env(ctx, None, &*source, env)?;
         // Create an executor that will run the lua script
         let ex = Executor::start(ctx, closure.into(), ());
 

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -1,7 +1,4 @@
-use std::{
-    hash::{Hash, Hasher},
-    io::Read,
-};
+use std::hash::{Hash, Hasher};
 
 use allocator_api2::{boxed, vec, SliceExt};
 use gc_arena::{allocator_api::MetricsAlloc, lock::Lock, Collect, Gc, Mutation};
@@ -115,7 +112,7 @@ impl<'gc> FunctionPrototype<'gc> {
     pub fn compile(
         ctx: Context<'gc>,
         source_name: &str,
-        source: impl Read,
+        source: &[u8],
     ) -> Result<FunctionPrototype<'gc>, CompilerError> {
         #[derive(Copy, Clone)]
         struct Interner<'gc>(Context<'gc>);
@@ -261,7 +258,7 @@ impl<'gc> Closure<'gc> {
     pub fn load(
         ctx: Context<'gc>,
         name: Option<&str>,
-        source: impl Read,
+        source: &[u8],
     ) -> Result<Closure<'gc>, CompilerError> {
         Self::load_with_env(ctx, name, source, ctx.globals())
     }
@@ -270,7 +267,7 @@ impl<'gc> Closure<'gc> {
     pub fn load_with_env(
         ctx: Context<'gc>,
         name: Option<&str>,
-        source: impl Read,
+        source: &[u8],
         env: Table<'gc>,
     ) -> Result<Closure<'gc>, CompilerError> {
         let proto = FunctionPrototype::compile(ctx, name.unwrap_or("<anonymous>"), source)?;

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -1,4 +1,4 @@
-use std::{io::Read, ops, rc::Rc};
+use std::{ops, rc::Rc};
 
 use thiserror::Error;
 
@@ -306,9 +306,8 @@ pub struct ParseError {
     pub line_number: LineNumber,
 }
 
-pub fn parse_chunk<R, S>(source: R, interner: S) -> Result<Chunk<S::String>, ParseError>
+pub fn parse_chunk<S>(source: &[u8], interner: S) -> Result<Chunk<S::String>, ParseError>
 where
-    R: Read,
     S: StringInterner,
 {
     Parser {
@@ -319,16 +318,13 @@ where
     .parse_chunk()
 }
 
-struct Parser<R, S: StringInterner> {
-    lexer: Lexer<R, S>,
+struct Parser<'a, S: StringInterner> {
+    lexer: Lexer<'a, S>,
     read_buffer: Vec<LineAnnotated<Token<S::String>>>,
     recursion_guard: Rc<()>,
 }
 
-impl<R, S: StringInterner> Parser<R, S>
-where
-    R: Read,
-{
+impl<S: StringInterner> Parser<'_, S> {
     fn parse_chunk(&mut self) -> Result<Chunk<S::String>, ParseError> {
         let block = self.parse_block()?;
         if !self.look_ahead(0)?.is_none() {


### PR DESCRIPTION
This makes the lexer (and in turn the parser) use byte slices rather than a generic `impl Read` for the program source.  This has two main benefits:
- `std::io::Read` is unsupported on `#![no_std]`, so we'll need to switch away from it eventually
- This should reduce compilation time and code size for crates that depend on `piccolo`.  Generic methods are instantiated in the calling crate, so currently each crate that loads Lua code compiles its own copy of the parser (and compiler, for reasons) for each type that `impl Read` is substituted for.  See #94 for more details, but this fixes the issue and supersedes #​94.