### PR TITLE
fix --repl flag in the interpreter example

### DIFF
--- a/examples/interpreter.rs
+++ b/examples/interpreter.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::{error::Error as StdError, io::Read};
 
-use clap::{crate_description, crate_name, crate_version, Arg, Command};
+use clap::{crate_description, crate_name, crate_version, Arg, ArgAction, Command};
 use rustyline::DefaultEditor;
 
 use piccolo::{
@@ -94,7 +94,8 @@ fn main() -> Result<(), Box<dyn StdError>> {
             Arg::new("repl")
                 .short('r')
                 .long("repl")
-                .help("Load into REPL after loading file, if any"),
+                .help("Load into REPL after loading file, if any")
+                .action(ArgAction::SetTrue),
         )
         .arg(Arg::new("file").help("File to interpret").index(1))
         .get_matches();
@@ -118,7 +119,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
     lua.execute::<()>(&executor)?;
 
-    if matches.contains_id("repl") {
+    if matches.get_flag("repl") {
         run_repl(&mut lua)?;
     }
 


### PR DESCRIPTION
I've been using the piccolo [interpreter example](https://github.com/kyren/piccolo/blob/master/examples/interpreter.rs) to do some development and it appears that a breaking change to clap made the `--repl` flag take an argument instead of being a boolean flag. This PR changes the flag to actually be a boolean, so
```
$ cargo run --release --example interpreter -- foo/bar.lua -r
error: a value is required for '--repl <repl>' but none was supplied

For more information, try '--help'.
```
is now
```
$ cargo run --release --example interpreter -- foo/bar.lua -r
<Lua program runs>
> 
```