### PR TITLE
Fix new lints for nightly CI

### DIFF
--- a/src/stack.rs
+++ b/src/stack.rs
@@ -109,7 +109,7 @@ impl<'gc, 'a> Stack<'gc, 'a> {
     pub fn drain<R: RangeBounds<usize>>(
         &mut self,
         range: R,
-    ) -> vec::Drain<Value<'gc>, MetricsAlloc<'gc>> {
+    ) -> vec::Drain<'_, Value<'gc>, MetricsAlloc<'gc>> {
         let start = match range.start_bound().cloned() {
             Bound::Included(r) => Bound::Included(self.bottom + r),
             Bound::Excluded(r) => Bound::Excluded(self.bottom + r),

--- a/src/string.rs
+++ b/src/string.rs
@@ -51,7 +51,7 @@ impl<'gc> String<'gc> {
             fn drop(&mut self) {
                 match self.header.buffer {
                     Buffer::Indirect(ptr) => unsafe {
-                        self.metrics.mark_external_deallocation((*ptr).len());
+                        self.metrics.mark_external_deallocation(ptr.len());
                         drop(Box::from_raw(ptr as *mut [u8]));
                     },
                     Buffer::Inline(_) => unreachable!(),

--- a/src/thread/thread.rs
+++ b/src/thread/thread.rs
@@ -214,7 +214,7 @@ impl<'gc> Thread<'gc> {
         &self,
         mc: &Mutation<'gc>,
         expected: ThreadMode,
-    ) -> Result<RefMut<ThreadState<'gc>>, BadThreadMode> {
+    ) -> Result<RefMut<'_, ThreadState<'gc>>, BadThreadMode> {
         assert!(expected != ThreadMode::Running);
         if let Ok(state) = self.0.try_borrow_mut(mc) {
             let found = state.mode();


### PR DESCRIPTION
Minor lint fixes so that our Miri runs in CI don't fail.  (As a side note, it would probably be good to pin the nightly version used for Miri in CI, to reduce unscheduled breakage?)