### PR TITLE
Revert #[error(transparent)] in CompilerError to fix downcasting

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -12,11 +12,14 @@ use crate::{
     Constant, Context, String, Table, Value,
 };
 
+// Note: These errors must not have #[error(transparent)] so that
+// anyhow::Error::root_cause and downcasting work as expected by the
+// interpreter. (Even though that gives slightly cleaner error messages).
 #[derive(Debug, Error)]
 pub enum CompilerError {
-    #[error(transparent)]
+    #[error("parse error")]
     Parsing(#[from] compiler::ParseError),
-    #[error(transparent)]
+    #[error("compile error")]
     Compilation(#[from] compiler::CompileError),
 }
 

--- a/tests/goldenscripts/close-multiple.lua
+++ b/tests/goldenscripts/close-multiple.lua
@@ -1,4 +1,4 @@
 --- error
---- runtime error: compiler error at line 4: multiple to-be-closed variables in local list
+--- runtime error: compile error: compiler error at line 4: multiple to-be-closed variables in local list
 
 local a <close>, b <close> = {}, {}

--- a/tests/goldenscripts/close-unimpl.lua
+++ b/tests/goldenscripts/close-unimpl.lua
@@ -1,4 +1,4 @@
 --- error
---- runtime error: compiler error at line 4: close attribute currently unsupported
+--- runtime error: compile error: compiler error at line 4: close attribute currently unsupported
 
 local c <close> = {}

--- a/tests/goldenscripts/const1.lua
+++ b/tests/goldenscripts/const1.lua
@@ -1,5 +1,5 @@
 --- error
---- runtime error: compiler error at line 5: cannot assign to a const variable
+--- runtime error: compile error: compiler error at line 5: cannot assign to a const variable
 
 local c <const> = 3
 c = 4

--- a/tests/goldenscripts/const3.lua
+++ b/tests/goldenscripts/const3.lua
@@ -1,5 +1,5 @@
 --- error
---- runtime error: compiler error at line 5: cannot assign to a const variable
+--- runtime error: compile error: compiler error at line 5: cannot assign to a const variable
 
 local a <const> = 3
 function a()

--- a/tests/goldenscripts/const4.lua
+++ b/tests/goldenscripts/const4.lua
@@ -1,5 +1,5 @@
 --- error
---- runtime error: compiler error at line 7: cannot assign to a const variable
+--- runtime error: compile error: compiler error at line 7: cannot assign to a const variable
 
 local a <const> = 3
 

--- a/tests/goldenscripts/const5.lua
+++ b/tests/goldenscripts/const5.lua
@@ -1,5 +1,5 @@
 --- error
---- runtime error: compiler error at line 7: cannot assign to a const variable
+--- runtime error: compile error: compiler error at line 7: cannot assign to a const variable
 
 local a <const> = 5
 


### PR DESCRIPTION
Fixes #120.

I've also added a note stating why it's structured as it is, since it's non-obvious and we don't have regression tests for the repl.