### PR TITLE
Do not call `__index` or `__newindex` from `table.insert`

### DIFF
--- a/src/stdlib/table.rs
+++ b/src/stdlib/table.rs
@@ -329,11 +329,7 @@ fn table_insert_impl<'gc>(
 
     let metatable = table.metatable();
     let use_fallback = metatable
-        .map(|mt| {
-            !mt.get_value(ctx, MetaMethod::Len).is_nil()
-                || !mt.get_value(ctx, MetaMethod::Index).is_nil()
-                || !mt.get_value(ctx, MetaMethod::NewIndex).is_nil()
-        })
+        .map(|mt| !mt.get_value(ctx, MetaMethod::Len).is_nil())
         .unwrap_or(false);
 
     if !use_fallback {
@@ -421,23 +417,23 @@ fn table_insert_impl<'gc>(
             if index < end_index {
                 // Could make this more efficient by inlining the stack manipulation;
                 // only pushing the table once.
-                for i in (index + 1..=end_index).rev() {
-                    // Push table[i - 1] onto the stack
-                    index_helper(&mut seq, &table, i - 1, 0).await?;
-                    let value = seq.enter(|ctx, locals, _, mut stack| {
-                        locals.stash(&ctx, stack.pop_back().unwrap_or_default())
-                    });
-                    // table[i] = table[i - 1]
-                    index_set_helper(&mut seq, &table, i, value, 0).await?;
-
-                    seq.enter(|_, _, mut exec, _| {
+                seq.try_enter(|ctx, locals, mut exec, _| {
+                    let table = locals.fetch(&table);
+                    for i in (index + 1..=end_index).rev() {
+                        let value = table.get_raw((i - 1).into());
+                        table.set_raw(&ctx, i.into(), value)?;
                         exec.fuel().consume(FUEL_PER_SHIFTED_ITEM as i32);
-                    });
-                }
+                    }
+                    Ok(())
+                })?;
             }
 
-            // table[index] = value
-            index_set_helper(&mut seq, &table, index, value, 0).await?;
+            seq.try_enter(|ctx, locals, _, _| {
+                let table = locals.fetch(&table);
+                let value = locals.fetch(&value);
+                table.set_raw(&ctx, index.into(), value)?;
+                Ok(())
+            })?;
 
             Ok(SequenceReturn::Return)
         }

--- a/tests/scripts/metaindex.lua
+++ b/tests/scripts/metaindex.lua
@@ -65,3 +65,24 @@ do
     t.foo = 4
     assert(idx.foo == 4)
 end
+
+do
+    local inserting = true
+    local t = setmetatable({}, {__len = function()
+        return 10
+    end,
+    __index = function(t, i)
+        if inserting then
+            error("table.insert should not call __index")
+        else
+            return rawget(t, i)
+        end
+    end,
+    __newindex = function(t, i, v)
+        error("table.insert should not call __newindex")
+    end})
+
+    table.insert(t, 42)
+    inserting = false
+    assert(t[11] == 42)
+end

--- a/tests/scripts/table.lua
+++ b/tests/scripts/table.lua
@@ -344,7 +344,6 @@ do
         log,
         {
             { "len" },
-            { "newindex", 6, 2 }
         }
     ))
 
@@ -360,15 +359,6 @@ do
         log,
         {
             { "len" },
-            { "index", 6 },
-            { "newindex", 7, 2 },
-            { "index", 5 },
-            { "newindex", 6, 8 },
-            { "index", 4 },
-            { "newindex", 5, 7 },
-            { "index", 3 },
-            { "newindex", 4, 6 },
-            { "newindex", 3, nil }
         }
     ))
 end


### PR DESCRIPTION
PUC-Lua does not do this and real world scripts rely on this not happening as they call `table.insert` from `__newindex`.