### PR TITLE
Show more detailed compiler error messages

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -17,9 +17,9 @@ use crate::{
 // interpreter. (Even though that gives slightly cleaner error messages).
 #[derive(Debug, Error)]
 pub enum CompilerError {
-    #[error("parse error")]
+    #[error("{0}")]
     Parsing(#[from] compiler::ParseError),
-    #[error("compile error")]
+    #[error("{0}")]
     Compilation(#[from] compiler::CompileError),
 }
 

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -333,7 +333,7 @@ pub enum ParseErrorKind {
     ExpressionNotStatement,
     #[error("recursion limit reached")]
     RecursionLimit,
-    #[error("lexer error")]
+    #[error("lexer error: {0}")]
     LexError(#[from] LexError),
     #[error("invalid attribute {0:?}")]
     InvalidAttribute(String),

--- a/tests/goldenscripts/close-multiple.lua
+++ b/tests/goldenscripts/close-multiple.lua
@@ -1,4 +1,4 @@
 --- error
---- runtime error: compile error: compiler error at line 4: multiple to-be-closed variables in local list
+--- runtime error: compiler error at line 4: multiple to-be-closed variables in local list
 
 local a <close>, b <close> = {}, {}

--- a/tests/goldenscripts/close-unimpl.lua
+++ b/tests/goldenscripts/close-unimpl.lua
@@ -1,4 +1,4 @@
 --- error
---- runtime error: compile error: compiler error at line 4: close attribute currently unsupported
+--- runtime error: compiler error at line 4: close attribute currently unsupported
 
 local c <close> = {}

--- a/tests/goldenscripts/const1.lua
+++ b/tests/goldenscripts/const1.lua
@@ -1,5 +1,5 @@
 --- error
---- runtime error: compile error: compiler error at line 5: cannot assign to a const variable
+--- runtime error: compiler error at line 5: cannot assign to a const variable
 
 local c <const> = 3
 c = 4

--- a/tests/goldenscripts/const3.lua
+++ b/tests/goldenscripts/const3.lua
@@ -1,5 +1,5 @@
 --- error
---- runtime error: compile error: compiler error at line 5: cannot assign to a const variable
+--- runtime error: compiler error at line 5: cannot assign to a const variable
 
 local a <const> = 3
 function a()

--- a/tests/goldenscripts/const4.lua
+++ b/tests/goldenscripts/const4.lua
@@ -1,5 +1,5 @@
 --- error
---- runtime error: compile error: compiler error at line 7: cannot assign to a const variable
+--- runtime error: compiler error at line 7: cannot assign to a const variable
 
 local a <const> = 3
 

--- a/tests/goldenscripts/const5.lua
+++ b/tests/goldenscripts/const5.lua
@@ -1,5 +1,5 @@
 --- error
---- runtime error: compile error: compiler error at line 7: cannot assign to a const variable
+--- runtime error: compiler error at line 7: cannot assign to a const variable
 
 local a <const> = 5
 

--- a/tests/goldenscripts/lexer.lua
+++ b/tests/goldenscripts/lexer.lua
@@ -1,0 +1,4 @@
+--- error
+--- runtime error: parse error at line 4: lexer error: invalid escape sequence
+
+local p = "\-"


### PR DESCRIPTION
On the last commit to master, transparent compiler errors were reverted, which, as noted, made the error messages a little worse. But what if it is possible to have the same good error messages too? :-)