### PR TITLE
Partial support for no_std

### DIFF
--- a/examples/compiler.rs
+++ b/examples/compiler.rs
@@ -1,11 +1,11 @@
-use std::{error::Error as StdError, fs::File, io::Read};
-
 use clap::{crate_description, crate_name, crate_version, Arg, Command};
-
-use piccolo::{
-    compiler::{self, interning::BasicInterner, string_utils::debug_utf8_lossy, CompiledPrototype},
-    io,
-};
+use piccolo::compiler::interning::BasicInterner;
+use piccolo::compiler::string_utils::debug_utf8_lossy;
+use piccolo::compiler::{self, CompiledPrototype};
+use piccolo::io;
+use std::error::Error as StdError;
+use std::fs::File;
+use std::io::Read;
 
 fn print_function<S: AsRef<[u8]>>(function: &CompiledPrototype<S>, depth: usize) {
     let indent = "  ".repeat(depth);

--- a/examples/execute.rs
+++ b/examples/execute.rs
@@ -1,7 +1,7 @@
+use piccolo::io::buffered_read;
+use piccolo::{Closure, Executor, Lua};
 use std::fs::File;
 use std::io::Read;
-
-use piccolo::{io::buffered_read, Closure, Executor, Lua};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load the Lua file

--- a/examples/interpreter.rs
+++ b/examples/interpreter.rs
@@ -1,14 +1,13 @@
-use std::fs::File;
-use std::{error::Error as StdError, io::Read};
-
 use clap::{crate_description, crate_name, crate_version, Arg, ArgAction, Command};
-use rustyline::DefaultEditor;
-
+use piccolo::compiler::{ParseError, ParseErrorKind};
 use piccolo::{
-    compiler::{ParseError, ParseErrorKind},
     io, meta_ops, Callback, CallbackReturn, Closure, Executor, ExternError, Function, Lua,
     StashedExecutor,
 };
+use rustyline::DefaultEditor;
+use std::error::Error as StdError;
+use std::fs::File;
+use std::io::Read;
 
 fn run_code(lua: &mut Lua, executor: &StashedExecutor, code: &str) -> Result<(), ExternError> {
     lua.try_enter(|ctx| {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+newline_style = "Unix"
+imports_granularity = "Module"
+group_imports = "One"

--- a/src/any.rs
+++ b/src/any.rs
@@ -1,9 +1,9 @@
+use core::any::TypeId;
+use core::fmt;
+use core::hash::{Hash, Hasher};
 use gc_arena::arena::Root;
 use gc_arena::barrier::{self, Write};
 use gc_arena::{Collect, Gc, Mutation, Rootable};
-use std::any::TypeId;
-use std::fmt;
-use std::hash::{Hash, Hasher};
 
 /// A `Gc` pointer to any type `T: Collect + 'gc` which allows safe downcasting.
 ///

--- a/src/any.rs
+++ b/src/any.rs
@@ -1,14 +1,9 @@
-use std::{
-    any::TypeId,
-    fmt,
-    hash::{Hash, Hasher},
-};
-
-use gc_arena::{
-    arena::Root,
-    barrier::{self, Write},
-    Collect, Gc, Mutation, Rootable,
-};
+use gc_arena::arena::Root;
+use gc_arena::barrier::{self, Write};
+use gc_arena::{Collect, Gc, Mutation, Rootable};
+use std::any::TypeId;
+use std::fmt;
+use std::hash::{Hash, Hasher};
 
 /// A `Gc` pointer to any type `T: Collect + 'gc` which allows safe downcasting.
 ///
@@ -187,9 +182,8 @@ impl<'gc, M> Any<'gc, M> {
 
 #[cfg(test)]
 mod tests {
-    use gc_arena::arena::rootless_mutate;
-
     use super::*;
+    use gc_arena::arena::rootless_mutate;
 
     #[test]
     fn test_any_value() {

--- a/src/async_callback.rs
+++ b/src/async_callback.rs
@@ -18,12 +18,12 @@ use gc_arena::{Collect, DynamicRootSet, Mutation};
 /// Can be used to implement `Sequence` in a way MUCH easier than manual state machines.
 ///
 /// Currently uses `async` to do what in the future could be more directly accomplished with
-/// coroutines (see the unstable [`std::ops::Coroutine`] trait). The [`std::task::Context`]
+/// coroutines (see the unstable [`core::ops::Coroutine`] trait). The [`core::task::Context`]
 /// available within the created future is **meaningless** and has a NOOP waker; we are only using
 /// `async` as a stable way to express what would be better expressed as a simple coroutine.
 ///
 /// It is possible to integrate proper async APIs with `piccolo`, and to even have a method to
-/// "wake" Lua coroutines with a *real* [`std::task::Waker`], but simply calling an external async
+/// "wake" Lua coroutines with a *real* [`core::task::Waker`], but simply calling an external async
 /// function from the created future here is *not* the way to do it. It will not do what you want,
 /// and probably will result in panics.
 ///

--- a/src/async_callback.rs
+++ b/src/async_callback.rs
@@ -3,14 +3,14 @@ use crate::{
     BoxSequence, Context, Error, Execution, Function, Sequence, SequencePoll, Stack, StashedError,
     StashedFunction, StashedThread, Thread,
 };
+use alloc::rc::Rc;
+use core::cell::Cell;
+use core::future::{poll_fn, Future};
+use core::marker::PhantomData;
+use core::pin::Pin;
+use core::task::{self, Poll, RawWaker, RawWakerVTable, Waker};
+use core::{mem, ptr};
 use gc_arena::{Collect, DynamicRootSet, Mutation};
-use std::cell::Cell;
-use std::future::{poll_fn, Future};
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::rc::Rc;
-use std::task::{self, Poll, RawWaker, RawWakerVTable, Waker};
-use std::{mem, ptr};
 
 /// Create a [`Sequence`] impl from a [`Future`] that can suspend, call Lua functions, yield to Lua,
 /// and resume threads as async method calls via a held [`AsyncSequence`] proxy.

--- a/src/async_callback.rs
+++ b/src/async_callback.rs
@@ -1,21 +1,16 @@
-use std::{
-    cell::Cell,
-    future::{poll_fn, Future},
-    marker::PhantomData,
-    mem,
-    pin::Pin,
-    ptr,
-    rc::Rc,
-    task::{self, Poll, RawWaker, RawWakerVTable, Waker},
-};
-
-use gc_arena::{Collect, DynamicRootSet, Mutation};
-
+use crate::stash::{Fetchable, Stashable};
 use crate::{
-    stash::{Fetchable, Stashable},
     BoxSequence, Context, Error, Execution, Function, Sequence, SequencePoll, Stack, StashedError,
     StashedFunction, StashedThread, Thread,
 };
+use gc_arena::{Collect, DynamicRootSet, Mutation};
+use std::cell::Cell;
+use std::future::{poll_fn, Future};
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{self, Poll, RawWaker, RawWakerVTable, Waker};
+use std::{mem, ptr};
 
 /// Create a [`Sequence`] impl from a [`Future`] that can suspend, call Lua functions, yield to Lua,
 /// and resume threads as async method calls via a held [`AsyncSequence`] proxy.

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,10 +1,10 @@
 use crate::{Context, Error, Execution, Function, Stack, Thread};
 use allocator_api2::boxed;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::pin::Pin;
 use gc_arena::allocator_api::MetricsAlloc;
 use gc_arena::{Collect, Gc, Mutation};
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::pin::Pin;
 
 /// Describes the next action for an [`Executor`](crate::Executor) to take after a callback has
 /// returned.

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,13 +1,10 @@
-use std::{
-    fmt,
-    hash::{Hash, Hasher},
-    pin::Pin,
-};
-
-use allocator_api2::boxed;
-use gc_arena::{allocator_api::MetricsAlloc, Collect, Gc, Mutation};
-
 use crate::{Context, Error, Execution, Function, Stack, Thread};
+use allocator_api2::boxed;
+use gc_arena::allocator_api::MetricsAlloc;
+use gc_arena::{Collect, Gc, Mutation};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
 
 /// Describes the next action for an [`Executor`](crate::Executor) to take after a callback has
 /// returned.

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -1,16 +1,14 @@
-use std::hash::{Hash, Hasher};
-
+use crate::compiler::{self, CompiledPrototype, FunctionRef, LineNumber};
+use crate::opcode::OpCode;
+use crate::thread::OpenUpValue;
+use crate::types::UpValueDescriptor;
+use crate::{Constant, Context, String, Table, Value};
 use allocator_api2::{boxed, vec, SliceExt};
-use gc_arena::{allocator_api::MetricsAlloc, lock::Lock, Collect, Gc, Mutation};
+use gc_arena::allocator_api::MetricsAlloc;
+use gc_arena::lock::Lock;
+use gc_arena::{Collect, Gc, Mutation};
+use std::hash::{Hash, Hasher};
 use thiserror::Error;
-
-use crate::{
-    compiler::{self, CompiledPrototype, FunctionRef, LineNumber},
-    opcode::OpCode,
-    thread::OpenUpValue,
-    types::UpValueDescriptor,
-    Constant, Context, String, Table, Value,
-};
 
 // Note: These errors must not have #[error(transparent)] so that
 // anyhow::Error::root_cause and downcasting work as expected by the

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -4,10 +4,10 @@ use crate::thread::OpenUpValue;
 use crate::types::UpValueDescriptor;
 use crate::{Constant, Context, String, Table, Value};
 use allocator_api2::{boxed, vec, SliceExt};
+use core::hash::{Hash, Hasher};
 use gc_arena::allocator_api::MetricsAlloc;
 use gc_arena::lock::Lock;
 use gc_arena::{Collect, Gc, Mutation};
-use std::hash::{Hash, Hasher};
 use thiserror::Error;
 
 // Note: These errors must not have #[error(transparent)] so that

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1,40 +1,31 @@
-use std::{
-    collections::{hash_map, VecDeque},
-    fmt, iter, mem,
+use super::lexer::LineNumber;
+use super::operators::{
+    categorize_binop, comparison_binop_const_fold, comparison_binop_operation,
+    simple_binop_const_fold, simple_binop_operation, unop_const_fold, unop_operation,
+    BinOpCategory, ComparisonBinOp, ShortCircuitBinOp, SimpleBinOp,
 };
-
+use super::parser::{
+    AssignmentStatement, AssignmentTarget, BinaryOperator, Block, CallSuffix, Chunk,
+    ConstructorField, Expression, FieldSuffix, ForStatement, FunctionCallStatement,
+    FunctionDefinition, FunctionStatement, HeadExpression, IfStatement, LocalAttributes,
+    LocalFunctionStatement, LocalStatement, PrimaryExpression, RecordKey, RepeatStatement,
+    ReturnStatement, SimpleExpression, Statement, SuffixPart, SuffixedExpression, TableConstructor,
+    UnaryOperator, WhileStatement,
+};
+use super::register_allocator::RegisterAllocator;
+use super::StringInterner;
+use crate::constant::IdenticalConstant;
+use crate::opcode::{OpCode, Operation, RCIndex};
+use crate::types::{
+    ConstantIndex16, ConstantIndex8, Opt254, PrototypeIndex, RegisterIndex, UpValueDescriptor,
+    UpValueIndex, VarCount,
+};
+use crate::Constant;
 use ahash::HashMap;
 use gc_arena::Collect;
+use std::collections::{hash_map, VecDeque};
+use std::{fmt, iter, mem};
 use thiserror::Error;
-
-use crate::{
-    constant::IdenticalConstant,
-    opcode::{OpCode, Operation, RCIndex},
-    types::{
-        ConstantIndex16, ConstantIndex8, Opt254, PrototypeIndex, RegisterIndex, UpValueDescriptor,
-        UpValueIndex, VarCount,
-    },
-    Constant,
-};
-
-use super::{
-    lexer::LineNumber,
-    operators::{
-        categorize_binop, comparison_binop_const_fold, comparison_binop_operation,
-        simple_binop_const_fold, simple_binop_operation, unop_const_fold, unop_operation,
-        BinOpCategory, ComparisonBinOp, ShortCircuitBinOp, SimpleBinOp,
-    },
-    parser::{
-        AssignmentStatement, AssignmentTarget, BinaryOperator, Block, CallSuffix, Chunk,
-        ConstructorField, Expression, FieldSuffix, ForStatement, FunctionCallStatement,
-        FunctionDefinition, FunctionStatement, HeadExpression, IfStatement, LocalAttributes,
-        LocalFunctionStatement, LocalStatement, PrimaryExpression, RecordKey, RepeatStatement,
-        ReturnStatement, SimpleExpression, Statement, SuffixPart, SuffixedExpression,
-        TableConstructor, UnaryOperator, WhileStatement,
-    },
-    register_allocator::RegisterAllocator,
-    StringInterner,
-};
 
 #[derive(Debug, Copy, Clone, Error)]
 pub enum CompileErrorKind {

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -22,9 +22,10 @@ use crate::types::{
 };
 use crate::Constant;
 use ahash::HashMap;
+use alloc::collections::VecDeque;
+use core::{fmt, iter, mem};
 use gc_arena::Collect;
-use std::collections::{hash_map, VecDeque};
-use std::{fmt, iter, mem};
+use std::collections::hash_map;
 use thiserror::Error;
 
 #[derive(Debug, Copy, Clone, Error)]

--- a/src/compiler/interning.rs
+++ b/src/compiler/interning.rs
@@ -1,5 +1,5 @@
 use ahash::HashSet;
-use std::rc::Rc;
+use alloc::rc::Rc;
 
 pub trait StringInterner {
     type String: AsRef<[u8]> + Clone;

--- a/src/compiler/interning.rs
+++ b/src/compiler/interning.rs
@@ -1,6 +1,5 @@
-use std::rc::Rc;
-
 use ahash::HashSet;
+use std::rc::Rc;
 
 pub trait StringInterner {
     type String: AsRef<[u8]> + Clone;

--- a/src/compiler/lexer.rs
+++ b/src/compiler/lexer.rs
@@ -1,17 +1,14 @@
-use std::{char, fmt};
-
-use gc_arena::Collect;
-use thiserror::Error;
-
+use super::string_utils::{
+    debug_utf8_lossy, is_alpha, is_digit, is_newline, FORM_FEED, VERTICAL_TAB,
+};
+use super::StringInterner;
 use crate::compiler::string_utils::{
     from_digit, from_hex_digit, is_hex_digit, is_space, read_dec_float, read_dec_integer,
     read_hex_float, read_hex_integer, ALERT_BEEP, BACKSPACE,
 };
-
-use super::{
-    string_utils::{debug_utf8_lossy, is_alpha, is_digit, is_newline, FORM_FEED, VERTICAL_TAB},
-    StringInterner,
-};
+use gc_arena::Collect;
+use std::{char, fmt};
+use thiserror::Error;
 
 #[derive(Clone)]
 pub enum Token<S> {
@@ -920,11 +917,9 @@ fn get_reserved_word_token<S>(word: &[u8]) -> Option<Token<S>> {
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
-    use crate::compiler::interning::BasicInterner;
-
     use super::*;
+    use crate::compiler::interning::BasicInterner;
+    use std::rc::Rc;
 
     fn test_tokens(source: &str, tokens: &[Token<Rc<[u8]>>]) {
         let mut lexer = Lexer::new(source.as_bytes(), BasicInterner::default());

--- a/src/compiler/lexer.rs
+++ b/src/compiler/lexer.rs
@@ -6,8 +6,8 @@ use crate::compiler::string_utils::{
     from_digit, from_hex_digit, is_hex_digit, is_space, read_dec_float, read_dec_integer,
     read_hex_float, read_hex_integer, ALERT_BEEP, BACKSPACE,
 };
+use core::{char, fmt};
 use gc_arena::Collect;
-use std::{char, fmt};
 use thiserror::Error;
 
 #[derive(Clone)]
@@ -919,7 +919,7 @@ fn get_reserved_word_token<S>(word: &[u8]) -> Option<Token<S>> {
 mod tests {
     use super::*;
     use crate::compiler::interning::BasicInterner;
-    use std::rc::Rc;
+    use alloc::rc::Rc;
 
     fn test_tokens(source: &str, tokens: &[Token<Rc<[u8]>>]) {
         let mut lexer = Lexer::new(source.as_bytes(), BasicInterner::default());

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -6,9 +6,9 @@ pub mod parser;
 mod register_allocator;
 pub mod string_utils;
 
-pub use self::{
-    compiler::{compile_chunk, CompileError, CompileErrorKind, CompiledPrototype, FunctionRef},
-    interning::StringInterner,
-    lexer::LineNumber,
-    parser::{parse_chunk, ParseError, ParseErrorKind},
+pub use self::compiler::{
+    compile_chunk, CompileError, CompileErrorKind, CompiledPrototype, FunctionRef,
 };
+pub use self::interning::StringInterner;
+pub use self::lexer::LineNumber;
+pub use self::parser::{parse_chunk, ParseError, ParseErrorKind};

--- a/src/compiler/operators.rs
+++ b/src/compiler/operators.rs
@@ -1,10 +1,7 @@
-use crate::{
-    opcode::{Operation, RCIndex},
-    types::RegisterIndex,
-    Constant,
-};
-
 use super::parser::{BinaryOperator, UnaryOperator};
+use crate::opcode::{Operation, RCIndex};
+use crate::types::RegisterIndex;
+use crate::Constant;
 
 // Binary operators which map directly to a single opcode
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -1,7 +1,7 @@
 use super::lexer::{LexError, Lexer, LineNumber, Token};
 use super::StringInterner;
-use std::rc::Rc;
-use std::{fmt, ops};
+use alloc::rc::Rc;
+use core::{fmt, ops};
 use thiserror::Error;
 
 #[derive(Debug, Clone)]

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -1,11 +1,8 @@
-use std::{fmt, ops, rc::Rc};
-
+use super::lexer::{LexError, Lexer, LineNumber, Token};
+use super::StringInterner;
+use std::rc::Rc;
+use std::{fmt, ops};
 use thiserror::Error;
-
-use super::{
-    lexer::{LexError, Lexer, LineNumber, Token},
-    StringInterner,
-};
 
 #[derive(Debug, Clone)]
 pub struct LineAnnotated<T> {

--- a/src/compiler/string_utils.rs
+++ b/src/compiler/string_utils.rs
@@ -1,7 +1,5 @@
-use std::{
-    fmt::{self, Write as _},
-    str,
-};
+use std::fmt::{self, Write as _};
+use std::str;
 
 pub fn trim_whitespace(mut s: &[u8]) -> &[u8] {
     s = &s[s.iter().position(|&c| !is_space(c)).unwrap_or(s.len())..];

--- a/src/compiler/string_utils.rs
+++ b/src/compiler/string_utils.rs
@@ -1,5 +1,5 @@
-use std::fmt::{self, Write as _};
-use std::str;
+use core::fmt::{self, Write as _};
+use core::str;
 
 pub fn trim_whitespace(mut s: &[u8]) -> &[u8] {
     s = &s[s.iter().position(|&c| !is_space(c)).unwrap_or(s.len())..];

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -1,6 +1,6 @@
 use crate::compiler::string_utils::{read_float, read_integer, trim_whitespace};
+use core::hash::{Hash, Hasher};
 use gc_arena::Collect;
-use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Copy, Clone, Collect)]
 #[collect(no_drop)]

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -1,8 +1,6 @@
-use std::hash::{Hash, Hasher};
-
-use gc_arena::Collect;
-
 use crate::compiler::string_utils::{read_float, read_integer, trim_whitespace};
+use gc_arena::Collect;
+use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Copy, Clone, Collect)]
 #[collect(no_drop)]

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,8 +1,8 @@
-use std::{array, iter, ops, string::String as StdString};
-
 use crate::{
     Callback, Closure, Context, Function, String, Table, Thread, TypeError, UserData, Value,
 };
+use std::string::String as StdString;
+use std::{array, iter, ops};
 
 pub trait IntoValue<'gc> {
     fn into_value(self, ctx: Context<'gc>) -> Value<'gc>;

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,8 +1,8 @@
 use crate::{
     Callback, Closure, Context, Function, String, Table, Thread, TypeError, UserData, Value,
 };
-use std::string::String as StdString;
-use std::{array, iter, ops};
+use alloc::string::String as StdString;
+use core::{array, iter, ops};
 
 pub trait IntoValue<'gc> {
     fn into_value(self, ctx: Context<'gc>) -> Value<'gc>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,11 +2,11 @@ use crate::{
     Callback, CallbackReturn, Context, FromValue, Function, IntoValue, MetaMethod, Singleton,
     Table, UserData, Value,
 };
+use alloc::string::String as StdString;
+use alloc::sync::Arc;
+use core::error::Error as StdError;
+use core::fmt;
 use gc_arena::{Collect, Gc, Rootable};
-use std::error::Error as StdError;
-use std::fmt;
-use std::string::String as StdString;
-use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, Error)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,13 @@
-use std::{error::Error as StdError, fmt, string::String as StdString, sync::Arc};
-
-use gc_arena::{Collect, Gc, Rootable};
-use thiserror::Error;
-
 use crate::{
     Callback, CallbackReturn, Context, FromValue, Function, IntoValue, MetaMethod, Singleton,
     Table, UserData, Value,
 };
+use gc_arena::{Collect, Gc, Rootable};
+use std::error::Error as StdError;
+use std::fmt;
+use std::string::String as StdString;
+use std::sync::Arc;
+use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, Error)]
 #[error("type error, expected {expected}, found {found}")]

--- a/src/finalizers.rs
+++ b/src/finalizers.rs
@@ -1,6 +1,7 @@
-use gc_arena::{lock::RefLock, Collect, Finalization, Gc, GcWeak, Mutation};
-
-use crate::{thread::ThreadInner, Thread};
+use crate::thread::ThreadInner;
+use crate::Thread;
+use gc_arena::lock::RefLock;
+use gc_arena::{Collect, Finalization, Gc, GcWeak, Mutation};
 
 #[derive(Copy, Clone, Collect)]
 #[collect(no_drop)]

--- a/src/function.rs
+++ b/src/function.rs
@@ -2,8 +2,8 @@ use crate::{
     BoxSequence, Callback, CallbackReturn, Closure, Context, Error, Execution, IntoMultiValue,
     Sequence, SequencePoll, Stack,
 };
+use core::pin::Pin;
 use gc_arena::{Collect, Gc, Mutation};
-use std::pin::Pin;
 
 /// Any callable Lua value (either a [`Closure`] or a [`Callback`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Collect)]

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,11 +1,9 @@
-use std::pin::Pin;
-
-use gc_arena::{Collect, Gc, Mutation};
-
 use crate::{
     BoxSequence, Callback, CallbackReturn, Closure, Context, Error, Execution, IntoMultiValue,
     Sequence, SequencePoll, Stack,
 };
+use gc_arena::{Collect, Gc, Mutation};
+use std::pin::Pin;
 
 /// Any callable Lua value (either a [`Closure`] or a [`Callback`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Collect)]

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufRead, BufReader, Read};
+use std::io::{BufRead, BufReader, Error, Read};
 
 /// Takes an `R: BufRead` and:
 ///
@@ -8,16 +8,14 @@ use std::io::{self, BufRead, BufReader, Read};
 ///
 /// This mimics the initial behavior of luaL_loadfile(x). In order to correctly detect and skip the
 /// BOM and unix shebang, the internal buffer of the BufRead must be >= 3 bytes.
-pub fn skip_prefix<R: BufRead>(r: &mut R) -> Result<(), io::Error> {
-    if {
-        let buf = r.fill_buf()?;
-        buf.len() >= 3 && buf[0] == 0xef && buf[1] == 0xbb && buf[2] == 0xbf
-    } {
+pub fn skip_prefix<R: BufRead>(r: &mut R) -> Result<(), Error> {
+    let buf = r.fill_buf()?;
+    if buf.len() >= 3 && buf[0] == 0xef && buf[1] == 0xbb && buf[2] == 0xbf {
         r.consume(3);
     }
 
     let buf = r.fill_buf()?;
-    let has_shebang = buf.len() >= 1 && buf[0] == b'#';
+    let has_shebang = !buf.is_empty() && buf[0] == b'#';
     if has_shebang {
         r.consume(1);
         loop {
@@ -46,7 +44,7 @@ pub fn skip_prefix<R: BufRead>(r: &mut R) -> Result<(), io::Error> {
 /// Reads a Lua script from a `R: Read` and wraps it in a BufReader
 ///
 /// Also calls `skip_prefix` to skip any leading UTF-8 BOM or unix shebang.
-pub fn buffered_read<R: Read>(r: R) -> Result<BufReader<R>, io::Error> {
+pub fn buffered_read<R: Read>(r: R) -> Result<BufReader<R>, Error> {
     let mut r = BufReader::new(r);
     skip_prefix(&mut r)?;
     Ok(r)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 pub mod any;
 pub mod async_callback;
 pub mod callback;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,26 +24,26 @@ pub mod types;
 pub mod userdata;
 pub mod value;
 
-pub use self::{
-    async_callback::{async_sequence, SequenceReturn},
-    callback::{BoxSequence, Callback, CallbackFn, CallbackReturn, Sequence, SequencePoll},
-    closure::{Closure, CompilerError, FunctionPrototype},
-    constant::Constant,
-    conversion::{FromMultiValue, FromValue, IntoMultiValue, IntoValue, Variadic},
-    error::{Error, ExternError, RuntimeError, TypeError},
-    fuel::Fuel,
-    function::Function,
-    lua::{Context, Lua},
-    meta_ops::MetaMethod,
-    registry::{Registry, Singleton},
-    stack::Stack,
-    stash::{
-        StashedCallback, StashedClosure, StashedError, StashedExecutor, StashedFunction,
-        StashedString, StashedTable, StashedThread, StashedUserData, StashedValue,
-    },
-    string::String,
-    table::Table,
-    thread::{Execution, Executor, ExecutorMode, Thread, ThreadMode},
-    userdata::UserData,
-    value::Value,
+pub use self::async_callback::{async_sequence, SequenceReturn};
+pub use self::callback::{
+    BoxSequence, Callback, CallbackFn, CallbackReturn, Sequence, SequencePoll,
 };
+pub use self::closure::{Closure, CompilerError, FunctionPrototype};
+pub use self::constant::Constant;
+pub use self::conversion::{FromMultiValue, FromValue, IntoMultiValue, IntoValue, Variadic};
+pub use self::error::{Error, ExternError, RuntimeError, TypeError};
+pub use self::fuel::Fuel;
+pub use self::function::Function;
+pub use self::lua::{Context, Lua};
+pub use self::meta_ops::MetaMethod;
+pub use self::registry::{Registry, Singleton};
+pub use self::stack::Stack;
+pub use self::stash::{
+    StashedCallback, StashedClosure, StashedError, StashedExecutor, StashedFunction, StashedString,
+    StashedTable, StashedThread, StashedUserData, StashedValue,
+};
+pub use self::string::String;
+pub use self::table::Table;
+pub use self::thread::{Execution, Executor, ExecutorMode, Thread, ThreadMode};
+pub use self::userdata::UserData;
+pub use self::value::Value;

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -7,10 +7,10 @@ use crate::{
     Error, ExternError, FromMultiValue, FromValue, Fuel, IntoValue, Registry, RuntimeError,
     Singleton, StashedExecutor, String, Table, TypeError, Value,
 };
+use core::ops;
 use gc_arena::arena::{CollectionPhase, Root};
 use gc_arena::metrics::Metrics;
 use gc_arena::{Arena, Collect, Mutation, Rootable};
-use std::ops;
 
 /// A value representing the main "execution context" of a Lua state.
 ///

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -1,20 +1,16 @@
-use std::ops;
-
-use gc_arena::{
-    arena::{CollectionPhase, Root},
-    metrics::Metrics,
-    Arena, Collect, Mutation, Rootable,
-};
-
+use crate::finalizers::Finalizers;
+use crate::stash::{Fetchable, Stashable};
+use crate::stdlib::{load_base, load_coroutine, load_io, load_math, load_string, load_table};
+use crate::string::InternedStringSet;
+use crate::thread::BadThreadMode;
 use crate::{
-    finalizers::Finalizers,
-    stash::{Fetchable, Stashable},
-    stdlib::{load_base, load_coroutine, load_io, load_math, load_string, load_table},
-    string::InternedStringSet,
-    thread::BadThreadMode,
     Error, ExternError, FromMultiValue, FromValue, Fuel, IntoValue, Registry, RuntimeError,
     Singleton, StashedExecutor, String, Table, TypeError, Value,
 };
+use gc_arena::arena::{CollectionPhase, Root};
+use gc_arena::metrics::Metrics;
+use gc_arena::{Arena, Collect, Mutation, Rootable};
+use std::ops;
 
 /// A value representing the main "execution context" of a Lua state.
 ///

--- a/src/meta_ops.rs
+++ b/src/meta_ops.rs
@@ -5,7 +5,6 @@ use crate::{
     Table, Value,
 };
 use gc_arena::Collect;
-use std::io::Write;
 use thiserror::Error;
 
 /// An enum of every possible Lua metamethod.
@@ -761,12 +760,7 @@ pub fn concat<'gc>(
         if a.is_implicit_string() && b.is_implicit_string() {
             let mut bytes = Vec::new();
             for value in [a, b] {
-                match value {
-                    Value::Integer(i) => write!(&mut bytes, "{}", i).unwrap(),
-                    Value::Number(n) => write!(&mut bytes, "{}", n).unwrap(),
-                    Value::String(s) => bytes.extend(s.as_bytes()),
-                    _ => return None,
-                }
+                value_to_string(&mut bytes, &value)?
             }
             Some(Value::String(ctx.intern(&bytes)))
         } else {
@@ -811,12 +805,7 @@ pub fn concat_many<'gc>(
 
         let mut bytes = Vec::with_capacity(len);
         for value in values {
-            match value {
-                Value::Integer(i) => write!(&mut bytes, "{i}").unwrap(),
-                Value::Number(n) => write!(&mut bytes, "{n}").unwrap(),
-                Value::String(s) => bytes.extend(s.as_bytes()),
-                _ => unreachable!(),
-            }
+            value_to_string(&mut bytes, value).unwrap();
         }
         return Ok(ConcatMetaResult::Value(Value::String(ctx.intern(&bytes))));
     }
@@ -825,7 +814,7 @@ pub fn concat_many<'gc>(
     let func = Callback::from_fn(&ctx, |ctx, _, stack| {
         let args = stack.len();
         let s = async_sequence(&ctx, |_, mut seq| async move {
-            for i in (1..args).into_iter().rev() {
+            for i in (1..args).rev() {
                 let call = seq.try_enter(|ctx, locals, _, mut stack| {
                     let bottom = i - 1;
                     let call = concat(ctx, stack[i - 1], stack[i])?;
@@ -875,21 +864,11 @@ pub fn concat_separated<'gc>(
 
         let mut iter = values.iter();
         if let Some(val) = iter.next() {
-            match val {
-                Value::Integer(i) => write!(&mut bytes, "{}", i).unwrap(),
-                Value::Number(n) => write!(&mut bytes, "{}", n).unwrap(),
-                Value::String(s) => bytes.extend(s.as_bytes()),
-                _ => unreachable!(),
-            }
+            value_to_string(&mut bytes, val).unwrap();
 
-            while let Some(val) = iter.next() {
+            for val in iter.by_ref() {
                 bytes.extend(&*sep_str);
-                match val {
-                    Value::Integer(i) => write!(&mut bytes, "{}", i).unwrap(),
-                    Value::Number(n) => write!(&mut bytes, "{}", n).unwrap(),
-                    Value::String(s) => bytes.extend(s.as_bytes()),
-                    _ => unreachable!(),
-                }
+                value_to_string(&mut bytes, val).unwrap();
             }
         }
         drop(iter);
@@ -903,7 +882,7 @@ pub fn concat_separated<'gc>(
         let b = async_sequence(&ctx, |locals, mut seq| {
             let sep = locals.stash(&ctx, sep);
             async move {
-                for i in (1..args).into_iter().rev() {
+                for i in (1..args).rev() {
                     let call = seq.try_enter(|ctx, locals, _, mut stack| {
                         let bottom = i;
                         let call = concat(ctx, locals.fetch(&sep), stack[i])?;
@@ -926,6 +905,16 @@ pub fn concat_separated<'gc>(
         Ok(CallbackReturn::Sequence(b))
     });
     Ok(ConcatMetaResult::Call(func.into()))
+}
+
+fn value_to_string(bytes: &mut Vec<u8>, value: &Value<'_>) -> Option<()> {
+    match value {
+        Value::Integer(i) => bytes.extend(i.to_string().as_bytes()),
+        Value::Number(n) => bytes.extend(n.to_string().as_bytes()),
+        Value::String(s) => bytes.extend(s.as_bytes()),
+        _ => return None,
+    }
+    Some(())
 }
 
 #[must_use]

--- a/src/meta_ops.rs
+++ b/src/meta_ops.rs
@@ -1,13 +1,12 @@
-use std::io::Write;
-
-use gc_arena::Collect;
-use thiserror::Error;
-
 use crate::async_callback::{AsyncSequence, Locals};
-use crate::{async_sequence, SequenceReturn, Stack};
+use crate::table::InvalidTableKey;
 use crate::{
-    table::InvalidTableKey, Callback, CallbackReturn, Context, Function, IntoValue, Table, Value,
+    async_sequence, Callback, CallbackReturn, Context, Function, IntoValue, SequenceReturn, Stack,
+    Table, Value,
 };
+use gc_arena::Collect;
+use std::io::Write;
+use thiserror::Error;
 
 /// An enum of every possible Lua metamethod.
 ///

--- a/src/meta_ops.rs
+++ b/src/meta_ops.rs
@@ -802,18 +802,18 @@ pub fn concat_many<'gc>(
 ) -> Result<ConcatMetaResult<'gc>, MetaOperatorError> {
     // Fast path scope; never loops, returns if successful, otherwise
     // breaks to fall back to the slow impl.
-    loop {
+    'fast: {
         // Since we have to make two passes to check for complex types,
         // estimate the length in the first pass.
         let Some(len) = estimate_concatenated_len(values)? else {
-            break;
+            break 'fast;
         };
 
         let mut bytes = Vec::with_capacity(len);
         for value in values {
             match value {
-                Value::Integer(i) => write!(&mut bytes, "{}", i).unwrap(),
-                Value::Number(n) => write!(&mut bytes, "{}", n).unwrap(),
+                Value::Integer(i) => write!(&mut bytes, "{i}").unwrap(),
+                Value::Number(n) => write!(&mut bytes, "{n}").unwrap(),
                 Value::String(s) => bytes.extend(s.as_bytes()),
                 _ => unreachable!(),
             }
@@ -852,16 +852,16 @@ pub fn concat_separated<'gc>(
 
     // Fast path scope; never loops, returns if successful, otherwise
     // breaks to fall back to the slow impl.
-    loop {
+    'fast: {
         let sep_str = match separator.into_string(ctx) {
             Some(s) => s,
-            None => break,
+            None => break 'fast,
         };
 
         // Since we have to make two passes to check for complex types,
         // estimate the length in the first pass.
         let Some(len) = estimate_concatenated_len(values)? else {
-            break;
+            break 'fast;
         };
 
         let sep_count = values.len().saturating_sub(1);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,8 +1,7 @@
-use gc_arena::Collect;
-
 use crate::types::{
     ConstantIndex16, ConstantIndex8, Opt254, PrototypeIndex, RegisterIndex, UpValueIndex, VarCount,
 };
+use gc_arena::Collect;
 
 #[derive(Debug, Copy, Clone, Collect)]
 #[collect(require_static)]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -2,13 +2,13 @@ use crate::any::Any;
 use crate::stash::{Fetchable, Stashable};
 use crate::Context;
 use ahash::AHasher;
+use core::any::TypeId;
+use core::hash::BuildHasherDefault;
 use gc_arena::allocator_api::MetricsAlloc;
 use gc_arena::arena::Root;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, DynamicRootSet, Gc, Mutation, Rootable};
 use hashbrown::{hash_map, HashMap};
-use std::any::TypeId;
-use std::hash::BuildHasherDefault;
 
 /// A type which can have a single registered value per [`Lua`](crate::Lua) instance.
 ///

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,17 +1,14 @@
-use std::{any::TypeId, hash::BuildHasherDefault};
-
+use crate::any::Any;
+use crate::stash::{Fetchable, Stashable};
+use crate::Context;
 use ahash::AHasher;
-use gc_arena::{
-    allocator_api::MetricsAlloc, arena::Root, lock::RefLock, Collect, DynamicRootSet, Gc, Mutation,
-    Rootable,
-};
+use gc_arena::allocator_api::MetricsAlloc;
+use gc_arena::arena::Root;
+use gc_arena::lock::RefLock;
+use gc_arena::{Collect, DynamicRootSet, Gc, Mutation, Rootable};
 use hashbrown::{hash_map, HashMap};
-
-use crate::{
-    any::Any,
-    stash::{Fetchable, Stashable},
-    Context,
-};
+use std::any::TypeId;
+use std::hash::BuildHasherDefault;
 
 /// A type which can have a single registered value per [`Lua`](crate::Lua) instance.
 ///

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,9 +1,9 @@
 use crate::{Context, FromMultiValue, FromValue, IntoMultiValue, IntoValue, TypeError, Value};
 use allocator_api2::vec;
+use core::iter;
+use core::ops::{Bound, Index, IndexMut, RangeBounds};
+use core::slice::{self, SliceIndex};
 use gc_arena::allocator_api::MetricsAlloc;
-use std::iter;
-use std::ops::{Bound, Index, IndexMut, RangeBounds};
-use std::slice::{self, SliceIndex};
 
 /// The mechanism through which all callbacks receive parameters and return values.
 ///

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,13 +1,9 @@
-use std::{
-    iter,
-    ops::{Bound, Index, IndexMut, RangeBounds},
-    slice::{self, SliceIndex},
-};
-
+use crate::{Context, FromMultiValue, FromValue, IntoMultiValue, IntoValue, TypeError, Value};
 use allocator_api2::vec;
 use gc_arena::allocator_api::MetricsAlloc;
-
-use crate::{Context, FromMultiValue, FromValue, IntoMultiValue, IntoValue, TypeError, Value};
+use std::iter;
+use std::ops::{Bound, Index, IndexMut, RangeBounds};
+use std::slice::{self, SliceIndex};
 
 /// The mechanism through which all callbacks receive parameters and return values.
 ///

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -1,17 +1,15 @@
-use std::fmt;
-
-use gc_arena::{DynamicRoot, DynamicRootSet, Mutation, Rootable};
-
+use crate::callback::CallbackInner;
+use crate::closure::ClosureInner;
+use crate::string::StringInner;
+use crate::table::TableInner;
+use crate::thread::{ExecutorInner, ThreadInner};
+use crate::userdata::UserDataInner;
 use crate::{
-    callback::CallbackInner,
-    closure::ClosureInner,
-    string::StringInner,
-    table::TableInner,
-    thread::{ExecutorInner, ThreadInner},
-    userdata::UserDataInner,
     Callback, Closure, Error, Executor, Function, RuntimeError, String, Table, Thread, UserData,
     Value,
 };
+use gc_arena::{DynamicRoot, DynamicRootSet, Mutation, Rootable};
+use std::fmt;
 
 /// A trait for types that can be stashed into a [`DynamicRootSet`].
 ///

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -8,8 +8,8 @@ use crate::{
     Callback, Closure, Error, Executor, Function, RuntimeError, String, Table, Thread, UserData,
     Value,
 };
+use core::fmt;
 use gc_arena::{DynamicRoot, DynamicRootSet, Mutation, Rootable};
-use std::fmt;
 
 /// A trait for types that can be stashed into a [`DynamicRootSet`].
 ///

--- a/src/stdlib/base.rs
+++ b/src/stdlib/base.rs
@@ -1,13 +1,11 @@
-use std::pin::Pin;
-
-use gc_arena::Collect;
-
+use crate::meta_ops::{self, MetaResult};
+use crate::table::NextValue;
 use crate::{
-    meta_ops::{self, MetaResult},
-    table::NextValue,
     BoxSequence, Callback, CallbackReturn, Context, Error, Execution, IntoValue, MetaMethod,
     Sequence, SequencePoll, Stack, String, Table, TypeError, Value, Variadic,
 };
+use gc_arena::Collect;
+use std::pin::Pin;
 
 pub fn load_base<'gc>(ctx: Context<'gc>) {
     ctx.set_global(

--- a/src/stdlib/base.rs
+++ b/src/stdlib/base.rs
@@ -4,8 +4,8 @@ use crate::{
     BoxSequence, Callback, CallbackReturn, Context, Error, Execution, IntoValue, MetaMethod,
     Sequence, SequencePoll, Stack, String, Table, TypeError, Value, Variadic,
 };
+use core::pin::Pin;
 use gc_arena::Collect;
-use std::pin::Pin;
 
 pub fn load_base<'gc>(ctx: Context<'gc>) {
     ctx.set_global(

--- a/src/stdlib/coroutine.rs
+++ b/src/stdlib/coroutine.rs
@@ -1,6 +1,5 @@
-use crate::{meta_ops, BoxSequence, Callback, CallbackReturn, Context, Table, Thread, ThreadMode};
-
 use super::base::PCall;
+use crate::{meta_ops, BoxSequence, Callback, CallbackReturn, Context, Table, Thread, ThreadMode};
 
 pub fn load_coroutine<'gc>(ctx: Context<'gc>) {
     let coroutine = Table::new(&ctx);

--- a/src/stdlib/io.rs
+++ b/src/stdlib/io.rs
@@ -1,15 +1,11 @@
-use std::{
-    io::{self, Write},
-    pin::Pin,
-};
-
-use gc_arena::Collect;
-
+use crate::meta_ops::{self, MetaResult};
 use crate::{
-    meta_ops::{self, MetaResult},
     BoxSequence, Callback, CallbackReturn, Context, Error, Execution, Sequence, SequencePoll,
     Stack, Value,
 };
+use gc_arena::Collect;
+use std::io::{self, Write};
+use std::pin::Pin;
 
 pub fn load_io<'gc>(ctx: Context<'gc>) {
     ctx.set_global(

--- a/src/stdlib/io.rs
+++ b/src/stdlib/io.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use core::pin::Pin;
 use gc_arena::Collect;
-use std::io::{self, Write};
+use std::io::{stdout, Write};
 
 pub fn load_io<'gc>(ctx: Context<'gc>) {
     ctx.set_global(
@@ -24,7 +24,7 @@ pub fn load_io<'gc>(ctx: Context<'gc>) {
                     _exec: Execution<'gc, '_>,
                     mut stack: Stack<'gc, '_>,
                 ) -> Result<SequencePoll<'gc>, Error<'gc>> {
-                    let mut stdout = io::stdout();
+                    let mut stdout = stdout();
 
                     while let Some(value) = stack.pop_back() {
                         match meta_ops::tostring(ctx, value)? {

--- a/src/stdlib/io.rs
+++ b/src/stdlib/io.rs
@@ -3,9 +3,9 @@ use crate::{
     BoxSequence, Callback, CallbackReturn, Context, Error, Execution, Sequence, SequencePoll,
     Stack, Value,
 };
+use core::pin::Pin;
 use gc_arena::Collect;
 use std::io::{self, Write};
-use std::pin::Pin;
 
 pub fn load_io<'gc>(ctx: Context<'gc>) {
     ctx.set_global(

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -1,9 +1,8 @@
-use gc_arena::Mutation;
-
 use crate::{
     async_sequence, meta_ops, Callback, CallbackReturn, Context, FromMultiValue, IntoMultiValue,
     IntoValue, SequenceReturn, Table, Value,
 };
+use gc_arena::Mutation;
 
 fn callback<'gc, F, A, R>(name: &'static str, mc: &Mutation<'gc>, f: F) -> Callback<'gc>
 where
@@ -289,9 +288,10 @@ pub fn load_trig<'gc>(ctx: Context<'gc>, math: Table<'gc>) {
 }
 
 pub fn load_random<'gc>(ctx: Context<'gc>, math: Table<'gc>) {
-    use std::{cell::RefCell, rc::Rc};
-
-    use rand::{rngs::SmallRng, Rng, SeedableRng};
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+    use std::cell::RefCell;
+    use std::rc::Rc;
 
     let seeded_rng = Rc::new(RefCell::new(SmallRng::from_entropy()));
 

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -288,10 +288,10 @@ pub fn load_trig<'gc>(ctx: Context<'gc>, math: Table<'gc>) {
 }
 
 pub fn load_random<'gc>(ctx: Context<'gc>, math: Table<'gc>) {
+    use alloc::rc::Rc;
+    use core::cell::RefCell;
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
-    use std::cell::RefCell;
-    use std::rc::Rc;
 
     let seeded_rng = Rc::new(RefCell::new(SmallRng::from_entropy()));
 

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -5,7 +5,9 @@ mod math;
 mod string;
 mod table;
 
-pub use self::{
-    base::load_base, coroutine::load_coroutine, io::load_io, math::load_math, string::load_string,
-    table::load_table,
-};
+pub use self::base::load_base;
+pub use self::coroutine::load_coroutine;
+pub use self::io::load_io;
+pub use self::math::load_math;
+pub use self::string::load_string;
+pub use self::table::load_table;

--- a/src/stdlib/string.rs
+++ b/src/stdlib/string.rs
@@ -100,7 +100,7 @@ pub fn load_string<'gc>(ctx: Context<'gc>) {
     ctx.set_global("string", string);
 }
 
-fn sub(string: &[u8], i: i64, j: Option<i64>) -> Result<&[u8], std::num::TryFromIntError> {
+fn sub(string: &[u8], i: i64, j: Option<i64>) -> Result<&[u8], core::num::TryFromIntError> {
     let i = match i {
         i if i > 0 => i.saturating_sub(1).try_into()?,
         0 => 0,

--- a/src/stdlib/table.rs
+++ b/src/stdlib/table.rs
@@ -1,19 +1,16 @@
-use std::mem;
-use std::pin::Pin;
-
+use crate::async_callback::{AsyncSequence, Locals};
+use crate::fuel::count_fuel;
+use crate::meta_ops::{self, concat_separated, ConcatMetaResult, MetaResult};
+use crate::table::RawTable;
+use crate::{
+    async_sequence, BoxSequence, Callback, CallbackReturn, Closure, Context, Error, Execution,
+    Function, IntoValue, MetaMethod, Sequence, SequencePoll, SequenceReturn, Stack, StashedError,
+    StashedFunction, StashedTable, StashedValue, Table, Value,
+};
 use anyhow::Context as _;
 use gc_arena::Collect;
-
-use crate::{
-    async_callback::{AsyncSequence, Locals},
-    async_sequence,
-    fuel::count_fuel,
-    meta_ops::{self, concat_separated, ConcatMetaResult, MetaResult},
-    table::RawTable,
-    BoxSequence, Callback, CallbackReturn, Closure, Context, Error, Execution, Function, IntoValue,
-    MetaMethod, Sequence, SequencePoll, SequenceReturn, Stack, StashedError, StashedFunction,
-    StashedTable, StashedValue, Table, Value,
-};
+use std::mem;
+use std::pin::Pin;
 
 pub fn load_table<'gc>(ctx: Context<'gc>) {
     let table = Table::new(&ctx);

--- a/src/stdlib/table.rs
+++ b/src/stdlib/table.rs
@@ -8,9 +8,9 @@ use crate::{
     StashedFunction, StashedTable, StashedValue, Table, Value,
 };
 use anyhow::Context as _;
+use core::mem;
+use core::pin::Pin;
 use gc_arena::Collect;
-use std::mem;
-use std::pin::Pin;
 
 pub fn load_table<'gc>(ctx: Context<'gc>) {
     let table = Table::new(&ctx);

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,5 +1,8 @@
 use crate::compiler::string_utils::{debug_utf8_lossy, display_utf8_lossy};
 use ahash::AHasher;
+use core::hash::{BuildHasherDefault, Hash, Hasher};
+use core::str::{self, Utf8Error};
+use core::{alloc, fmt, ops, slice};
 use gc_arena::allocator_api::MetricsAlloc;
 use gc_arena::barrier::Unlock;
 use gc_arena::lock::RefLock;
@@ -7,9 +10,6 @@ use gc_arena::metrics::Metrics;
 use gc_arena::{Collect, Collection, Gc, GcWeak, Mutation, Static};
 use hashbrown::raw::RawTable;
 use hashbrown::{hash_map, HashMap};
-use std::hash::{BuildHasherDefault, Hash, Hasher};
-use std::str::{self, Utf8Error};
-use std::{alloc, fmt, ops, slice};
 
 /// The Lua string type.
 ///

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,18 +1,15 @@
-use std::{
-    alloc, fmt,
-    hash::{BuildHasherDefault, Hash, Hasher},
-    ops, slice,
-    str::{self, Utf8Error},
-};
-
-use ahash::AHasher;
-use gc_arena::{
-    allocator_api::MetricsAlloc, barrier::Unlock, lock::RefLock, metrics::Metrics, Collect,
-    Collection, Gc, GcWeak, Mutation, Static,
-};
-use hashbrown::{hash_map, raw::RawTable, HashMap};
-
 use crate::compiler::string_utils::{debug_utf8_lossy, display_utf8_lossy};
+use ahash::AHasher;
+use gc_arena::allocator_api::MetricsAlloc;
+use gc_arena::barrier::Unlock;
+use gc_arena::lock::RefLock;
+use gc_arena::metrics::Metrics;
+use gc_arena::{Collect, Collection, Gc, GcWeak, Mutation, Static};
+use hashbrown::raw::RawTable;
+use hashbrown::{hash_map, HashMap};
+use std::hash::{BuildHasherDefault, Hash, Hasher};
+use std::str::{self, Utf8Error};
+use std::{alloc, fmt, ops, slice};
 
 /// The Lua string type.
 ///
@@ -365,9 +362,8 @@ impl<'gc> InternedStringSet<'gc> {
 
 #[cfg(test)]
 mod tests {
-    use gc_arena::arena::rootless_mutate;
-
     use super::*;
+    use gc_arena::arena::rootless_mutate;
 
     #[test]
     fn test_string_header() {

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,7 +1,5 @@
 mod raw;
 mod table;
 
-pub use self::{
-    raw::{InvalidTableKey, NextValue, RawTable},
-    table::{Table, TableInner, TableState},
-};
+pub use self::raw::{InvalidTableKey, NextValue, RawTable};
+pub use self::table::{Table, TableInner, TableState};

--- a/src/table/raw.rs
+++ b/src/table/raw.rs
@@ -1,11 +1,11 @@
-use std::{fmt, hash::Hash, i64, mem};
-
-use allocator_api2::vec;
-use gc_arena::{allocator_api::MetricsAlloc, Collect, Gc, Mutation};
-use hashbrown::{hash_map, HashMap};
-use thiserror::Error;
-
 use crate::{Callback, Closure, Function, String, Table, Thread, UserData, Value};
+use allocator_api2::vec;
+use gc_arena::allocator_api::MetricsAlloc;
+use gc_arena::{Collect, Gc, Mutation};
+use hashbrown::{hash_map, HashMap};
+use std::hash::Hash;
+use std::{fmt, i64, mem};
+use thiserror::Error;
 
 #[derive(Debug, Copy, Clone, Error)]
 pub enum InvalidTableKey {

--- a/src/table/raw.rs
+++ b/src/table/raw.rs
@@ -1,10 +1,10 @@
 use crate::{Callback, Closure, Function, String, Table, Thread, UserData, Value};
 use allocator_api2::vec;
+use core::hash::Hash;
+use core::{fmt, i64, mem};
 use gc_arena::allocator_api::MetricsAlloc;
 use gc_arena::{Collect, Gc, Mutation};
 use hashbrown::{hash_map, HashMap};
-use std::hash::Hash;
-use std::{fmt, i64, mem};
 use thiserror::Error;
 
 #[derive(Debug, Copy, Clone, Error)]

--- a/src/table/table.rs
+++ b/src/table/table.rs
@@ -1,9 +1,9 @@
 use super::raw::{InvalidTableKey, NextValue, RawTable};
 use crate::{Context, FromValue, IntoValue, TypeError, Value};
+use core::hash::{Hash, Hasher};
+use core::{fmt, i64, mem};
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, Mutation};
-use std::hash::{Hash, Hasher};
-use std::{fmt, i64, mem};
 
 pub type TableInner<'gc> = RefLock<TableState<'gc>>;
 

--- a/src/table/table.rs
+++ b/src/table/table.rs
@@ -1,14 +1,9 @@
-use std::{
-    fmt,
-    hash::{Hash, Hasher},
-    i64, mem,
-};
-
-use gc_arena::{lock::RefLock, Collect, Gc, Mutation};
-
-use crate::{Context, FromValue, IntoValue, TypeError, Value};
-
 use super::raw::{InvalidTableKey, NextValue, RawTable};
+use crate::{Context, FromValue, IntoValue, TypeError, Value};
+use gc_arena::lock::RefLock;
+use gc_arena::{Collect, Gc, Mutation};
+use std::hash::{Hash, Hasher};
+use std::{fmt, i64, mem};
 
 pub type TableInner<'gc> = RefLock<TableState<'gc>>;
 

--- a/src/thread/executor.rs
+++ b/src/thread/executor.rs
@@ -1,20 +1,17 @@
-use std::hash::{Hash, Hasher};
-
-use allocator_api2::vec;
-use gc_arena::{allocator_api::MetricsAlloc, lock::RefLock, Collect, Gc, Mutation};
-use thiserror::Error;
-
+use super::thread::{Frame, LuaFrame, ThreadState};
+use super::vm::run_vm;
+use crate::compiler::{FunctionRef, LineNumber};
+use crate::thread::BadThreadMode;
 use crate::{
-    compiler::{FunctionRef, LineNumber},
-    thread::BadThreadMode,
     CallbackReturn, Context, Error, FromMultiValue, Fuel, Function, IntoMultiValue, SequencePoll,
     Stack, String, Thread, ThreadMode, Variadic,
 };
-
-use super::{
-    thread::{Frame, LuaFrame, ThreadState},
-    vm::run_vm,
-};
+use allocator_api2::vec;
+use gc_arena::allocator_api::MetricsAlloc;
+use gc_arena::lock::RefLock;
+use gc_arena::{Collect, Gc, Mutation};
+use std::hash::{Hash, Hasher};
+use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecutorMode {

--- a/src/thread/executor.rs
+++ b/src/thread/executor.rs
@@ -7,10 +7,10 @@ use crate::{
     Stack, String, Thread, ThreadMode, Variadic,
 };
 use allocator_api2::vec;
+use core::hash::{Hash, Hasher};
 use gc_arena::allocator_api::MetricsAlloc;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Gc, Mutation};
-use std::hash::{Hash, Hasher};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -2,17 +2,12 @@ mod executor;
 mod thread;
 mod vm;
 
-use thiserror::Error;
-
-use crate::meta_ops::{MetaCallError, MetaOperatorError};
-
-pub use self::{
-    executor::{
-        BadExecutorMode, CurrentThread, Execution, Executor, ExecutorInner, ExecutorMode,
-        UpperLuaFrame,
-    },
-    thread::{BadThreadMode, OpenUpValue, Thread, ThreadInner, ThreadMode},
+pub use self::executor::{
+    BadExecutorMode, CurrentThread, Execution, Executor, ExecutorInner, ExecutorMode, UpperLuaFrame,
 };
+pub use self::thread::{BadThreadMode, OpenUpValue, Thread, ThreadInner, ThreadMode};
+use crate::meta_ops::{MetaCallError, MetaOperatorError};
+use thiserror::Error;
 
 #[derive(Debug, Clone, Error)]
 pub enum VMError {

--- a/src/thread/thread.rs
+++ b/src/thread/thread.rs
@@ -1,24 +1,18 @@
-use std::{
-    cell::RefMut,
-    hash::{Hash, Hasher},
-};
-
-use allocator_api2::vec;
-use gc_arena::{
-    allocator_api::MetricsAlloc, lock::RefLock, Collect, Finalization, Gc, GcWeak, Mutation,
-};
-use thiserror::Error;
-
-use crate::{
-    closure::{UpValue, UpValueState},
-    fuel::count_fuel,
-    meta_ops,
-    types::{RegisterIndex, VarCount},
-    BoxSequence, Callback, Closure, Context, Error, FromMultiValue, Fuel, Function, IntoMultiValue,
-    String, Table, UserData, Value,
-};
-
 use super::VMError;
+use crate::closure::{UpValue, UpValueState};
+use crate::fuel::count_fuel;
+use crate::types::{RegisterIndex, VarCount};
+use crate::{
+    meta_ops, BoxSequence, Callback, Closure, Context, Error, FromMultiValue, Fuel, Function,
+    IntoMultiValue, String, Table, UserData, Value,
+};
+use allocator_api2::vec;
+use gc_arena::allocator_api::MetricsAlloc;
+use gc_arena::lock::RefLock;
+use gc_arena::{Collect, Finalization, Gc, GcWeak, Mutation};
+use std::cell::RefMut;
+use std::hash::{Hash, Hasher};
+use thiserror::Error;
 
 /// The current state of a [`Thread`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/thread/thread.rs
+++ b/src/thread/thread.rs
@@ -7,11 +7,11 @@ use crate::{
     IntoMultiValue, String, Table, UserData, Value,
 };
 use allocator_api2::vec;
+use core::cell::RefMut;
+use core::hash::{Hash, Hasher};
 use gc_arena::allocator_api::MetricsAlloc;
 use gc_arena::lock::RefLock;
 use gc_arena::{Collect, Finalization, Gc, GcWeak, Mutation};
-use std::cell::RefMut;
-use std::hash::{Hash, Hasher};
 use thiserror::Error;
 
 /// The current state of a [`Thread`].

--- a/src/thread/vm.rs
+++ b/src/thread/vm.rs
@@ -1,16 +1,13 @@
+use super::thread::LuaFrame;
+use super::VMError;
+use crate::meta_ops::{self, ConcatMetaResult, MetaResult};
+use crate::opcode::{Operation, RCIndex};
+use crate::table::RawTable;
+use crate::thread::thread::MetaReturn;
+use crate::types::{RegisterIndex, UpValueDescriptor, VarCount};
+use crate::{Closure, Constant, Context, Function, String, Table, Value};
 use allocator_api2::vec;
 use gc_arena::allocator_api::MetricsAlloc;
-
-use crate::{
-    meta_ops::{self, ConcatMetaResult, MetaResult},
-    opcode::{Operation, RCIndex},
-    table::RawTable,
-    thread::thread::MetaReturn,
-    types::{RegisterIndex, UpValueDescriptor, VarCount},
-    Closure, Constant, Context, Function, String, Table, Value,
-};
-
-use super::{thread::LuaFrame, VMError};
 
 // Runs the VM for the given number of instructions or until the current LuaFrame may have been
 // changed.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,5 @@
-use std::fmt::{self, Debug};
-
 use gc_arena::Collect;
+use std::fmt::{self, Debug};
 
 /// An index that points to a register in the stack relative to the current frame.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Collect)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
+use core::fmt::{self, Debug};
 use gc_arena::Collect;
-use std::fmt::{self, Debug};
 
 /// An index that points to a register in the stack relative to the current frame.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Collect)]

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -1,9 +1,9 @@
 use crate::any::{Any, AnyInner};
 use crate::Table;
+use core::hash::{Hash, Hasher};
+use core::mem;
 use gc_arena::arena::Root;
 use gc_arena::{barrier, lock, Collect, Gc, Mutation, Rootable, Static};
-use std::hash::{Hash, Hasher};
-use std::mem;
 use thiserror::Error;
 
 #[derive(Debug, Copy, Clone, Error)]

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -1,15 +1,10 @@
-use std::{
-    hash::{Hash, Hasher},
-    mem,
-};
-
-use gc_arena::{arena::Root, barrier, lock, Collect, Gc, Mutation, Rootable, Static};
+use crate::any::{Any, AnyInner};
+use crate::Table;
+use gc_arena::arena::Root;
+use gc_arena::{barrier, lock, Collect, Gc, Mutation, Rootable, Static};
+use std::hash::{Hash, Hasher};
+use std::mem;
 use thiserror::Error;
-
-use crate::{
-    any::{Any, AnyInner},
-    Table,
-};
 
 #[derive(Debug, Copy, Clone, Error)]
 #[error("UserData type mismatch")]

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -33,7 +33,7 @@ pub type UserDataInner<'gc> = AnyInner<UserDataMetaState<'gc>>;
 ///
 /// There is no automatic mechanism to provide internal mutability on the held value. If the held
 /// value needs to be internally mutable and is `'static`, consider normal mechanisms for Rust
-/// internal mutability like [`std::cell::RefCell`]. If the type is a GC type and needs to be
+/// internal mutability like [`core::cell::RefCell`]. If the type is a GC type and needs to be
 /// internally mutable, use the mechanisms in `gc-arena` for this like [`gc_arena::lock::RefLock`]
 /// instead.
 ///

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,8 +1,6 @@
-use std::{f64, fmt, i64};
-
-use gc_arena::{Collect, Gc};
-
 use crate::{Callback, Closure, Constant, Function, String, Table, Thread, UserData};
+use gc_arena::{Collect, Gc};
+use std::{f64, fmt, i64};
 
 /// The single data type for all Lua variables.
 ///
@@ -261,10 +259,9 @@ impl<'gc> From<UserData<'gc>> for Value<'gc> {
 
 #[cfg(test)]
 mod tests {
-    use gc_arena::Rootable;
-
     use crate::table::Table;
     use crate::{Lua, UserData};
+    use gc_arena::Rootable;
 
     #[test]
     fn recursive_table_debug() {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,6 @@
 use crate::{Callback, Closure, Constant, Function, String, Table, Thread, UserData};
+use core::{f64, fmt, i64};
 use gc_arena::{Collect, Gc};
-use std::{f64, fmt, i64};
 
 /// The single data type for all Lua variables.
 ///

--- a/src/value.rs
+++ b/src/value.rs
@@ -54,7 +54,7 @@ impl<'gc> Value<'gc> {
         struct ValueDisplay<'gc>(Value<'gc>);
 
         impl<'gc> fmt::Display for ValueDisplay<'gc> {
-            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> core::fmt::Result {
                 match self.0 {
                     Value::Nil => write!(fmt, "nil"),
                     Value::Boolean(b) => write!(fmt, "{}", b),
@@ -83,7 +83,7 @@ impl<'gc> Value<'gc> {
         struct ShallowDebug<'gc>(Value<'gc>);
 
         impl<'gc> fmt::Debug for ShallowDebug<'gc> {
-            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> core::fmt::Result {
                 match self.0 {
                     Value::Table(t) => {
                         write!(fmt, "Value::Table({:p})", Gc::as_ptr(t.into_inner()))

--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -1,10 +1,9 @@
-use std::pin::Pin;
-
 use gc_arena::Collect;
 use piccolo::{
     BoxSequence, Callback, CallbackReturn, Closure, Context, Error, Execution, Executor,
     ExternError, Function, IntoValue, Lua, Sequence, SequencePoll, Stack, String, Thread, Value,
 };
+use std::pin::Pin;
 
 #[test]
 fn callback() -> Result<(), ExternError> {

--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -1,9 +1,9 @@
+use core::pin::Pin;
 use gc_arena::Collect;
 use piccolo::{
     BoxSequence, Callback, CallbackReturn, Closure, Context, Error, Execution, Executor,
     ExternError, Function, IntoValue, Lua, Sequence, SequencePoll, Stack, String, Thread, Value,
 };
-use std::pin::Pin;
 
 #[test]
 fn callback() -> Result<(), ExternError> {

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,4 +1,5 @@
-use piccolo::{error::LuaError, Callback, Closure, Error, Executor, ExternError, Lua, Value};
+use piccolo::error::LuaError;
+use piccolo::{Callback, Closure, Error, Executor, ExternError, Lua, Value};
 use thiserror::Error;
 
 #[test]

--- a/tests/goldenscripts.rs
+++ b/tests/goldenscripts.rs
@@ -11,23 +11,23 @@
 //! where `mode` dictates how to handle errors
 //! and `script` is a valid Lua script.
 
-use piccolo::{Closure, Executor, Lua};
-use std::{fs::read_dir, io::BufRead, path::PathBuf, sync::mpsc::channel};
-
 use crate::collected_print::print_callback;
+use piccolo::{Closure, Executor, Lua};
+use std::fs::read_dir;
+use std::io::BufRead;
+use std::path::PathBuf;
+use std::sync::mpsc::channel;
 
 mod collected_print {
     use gc_arena::Collect;
+    use piccolo::meta_ops::{self, MetaResult};
     use piccolo::{
-        meta_ops::{self, MetaResult},
         BoxSequence, Callback, CallbackReturn, Context, Execution, Sequence, SequencePoll, Stack,
         Value,
     };
-    use std::{
-        io::{Cursor, Write},
-        pin::Pin,
-        sync::mpsc::Sender,
-    };
+    use std::io::{Cursor, Write};
+    use std::pin::Pin;
+    use std::sync::mpsc::Sender;
 
     pub fn print_callback<'gc>(ctx: piccolo::Context<'gc>, tx: Sender<Vec<u8>>) -> Callback<'gc> {
         Callback::from_fn(

--- a/tests/scripts.rs
+++ b/tests/scripts.rs
@@ -1,9 +1,6 @@
-use std::{
-    fs::{read_dir, File},
-    io::{stdout, Read, Write},
-};
-
 use piccolo::{io, Closure, Executor, ExternError, Lua};
+use std::fs::{read_dir, File};
+use std::io::{stdout, Read, Write};
 
 fn run_lua_code(name: &str, code: &[u8]) -> Result<(), ExternError> {
     let mut lua = Lua::full();

--- a/tests/sizes.rs
+++ b/tests/sizes.rs
@@ -1,6 +1,6 @@
+use piccolo::opcode::OpCode;
+use piccolo::{Callback, Closure, String, Table, Thread, UserData, Value};
 use std::mem;
-
-use piccolo::{opcode::OpCode, Callback, Closure, String, Table, Thread, UserData, Value};
 
 #[test]
 fn test_sizes() {

--- a/tests/sizes.rs
+++ b/tests/sizes.rs
@@ -1,6 +1,6 @@
+use core::mem;
 use piccolo::opcode::OpCode;
 use piccolo::{Callback, Closure, String, Table, Thread, UserData, Value};
-use std::mem;
 
 #[test]
 fn test_sizes() {

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -1,6 +1,5 @@
-use std::cmp::Ordering;
-
 use piccolo::{Lua, Table, Value};
+use std::cmp::Ordering;
 
 #[test]
 fn test_table_iter() {

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -1,5 +1,5 @@
+use core::cmp::Ordering;
 use piccolo::{Lua, Table, Value};
-use std::cmp::Ordering;
 
 #[test]
 fn test_table_iter() {

--- a/tests/tail_call_stack_panic.rs
+++ b/tests/tail_call_stack_panic.rs
@@ -1,6 +1,6 @@
+use piccolo::meta_ops::MetaCallError;
+use piccolo::{Closure, Executor, Lua};
 use std::string::String as StdString;
-
-use piccolo::{meta_ops::MetaCallError, Closure, Executor, Lua};
 
 const SOURCE: &str = r#"
     -- Purposeful typo of 'tostring'

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -1,4 +1,5 @@
-use gc_arena::{lock::Lock, Collect, Gc, Rootable};
+use gc_arena::lock::Lock;
+use gc_arena::{Collect, Gc, Rootable};
 use piccolo::{Callback, CallbackReturn, Closure, Executor, Lua, UserData, Value};
 
 #[derive(Collect)]

--- a/util/src/freeze.rs
+++ b/util/src/freeze.rs
@@ -1,5 +1,7 @@
-use std::{cell::RefCell, marker::PhantomData, mem, rc::Rc};
-
+use std::cell::RefCell;
+use std::marker::PhantomData;
+use std::mem;
+use std::rc::Rc;
 use thiserror::Error;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Error)]

--- a/util/src/freeze.rs
+++ b/util/src/freeze.rs
@@ -1,7 +1,7 @@
-use std::cell::RefCell;
-use std::marker::PhantomData;
-use std::mem;
-use std::rc::Rc;
+use alloc::rc::Rc;
+use core::cell::RefCell;
+use core::marker::PhantomData;
+use core::mem;
 use thiserror::Error;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Error)]

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 pub mod freeze;
 pub mod user_methods;
 

--- a/util/src/serde/de.rs
+++ b/util/src/serde/de.rs
@@ -1,8 +1,8 @@
 use super::markers::{is_none, is_unit};
+use core::fmt;
 use piccolo::table::NextValue;
 use piccolo::{Table, Value};
 use serde::de;
-use std::fmt;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/util/src/serde/de.rs
+++ b/util/src/serde/de.rs
@@ -1,10 +1,9 @@
-use std::fmt;
-
-use piccolo::{table::NextValue, Table, Value};
-use serde::de;
-use thiserror::Error;
-
 use super::markers::{is_none, is_unit};
+use piccolo::table::NextValue;
+use piccolo::{Table, Value};
+use serde::de;
+use std::fmt;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/util/src/serde/mod.rs
+++ b/util/src/serde/mod.rs
@@ -2,12 +2,9 @@ pub mod de;
 pub mod markers;
 pub mod ser;
 
+pub use self::de::from_value;
+pub use self::ser::{to_value, to_value_with, Options as SerOptions};
 use piccolo::Lua;
-
-pub use self::{
-    de::from_value,
-    ser::{to_value, to_value_with, Options as SerOptions},
-};
 
 pub trait LuaSerdeExt {
     fn load_serde(&mut self);

--- a/util/src/serde/ser.rs
+++ b/util/src/serde/ser.rs
@@ -1,7 +1,7 @@
 use super::markers::{none, unit};
+use core::fmt;
 use piccolo::{Context, Table, Value};
 use serde::ser;
-use std::fmt;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/util/src/serde/ser.rs
+++ b/util/src/serde/ser.rs
@@ -1,10 +1,8 @@
-use std::fmt;
-
+use super::markers::{none, unit};
 use piccolo::{Context, Table, Value};
 use serde::ser;
+use std::fmt;
 use thiserror::Error;
-
-use super::markers::{none, unit};
 
 #[derive(Debug, Error)]
 #[error("{0}")]

--- a/util/src/user_methods.rs
+++ b/util/src/user_methods.rs
@@ -1,10 +1,10 @@
+use core::marker::PhantomData;
 use gc_arena::arena::Root;
 use gc_arena::{barrier, Collect, Rootable, Static};
 use piccolo::{
     Callback, CallbackReturn, Context, Error, Execution, FromMultiValue, IntoMultiValue,
     MetaMethod, Table, UserData,
 };
-use std::marker::PhantomData;
 
 /// An easy way to wrap a value in [`UserData`] and let Lua call methods on it.
 ///

--- a/util/src/user_methods.rs
+++ b/util/src/user_methods.rs
@@ -1,10 +1,10 @@
-use std::marker::PhantomData;
-
-use gc_arena::{arena::Root, barrier, Collect, Rootable, Static};
+use gc_arena::arena::Root;
+use gc_arena::{barrier, Collect, Rootable, Static};
 use piccolo::{
     Callback, CallbackReturn, Context, Error, Execution, FromMultiValue, IntoMultiValue,
     MetaMethod, Table, UserData,
 };
+use std::marker::PhantomData;
 
 /// An easy way to wrap a value in [`UserData`] and let Lua call methods on it.
 ///


### PR DESCRIPTION
This is the first step to support `no_std`. I've flattened imports (to make the next step easier), replaced `std` with `core` and `alloc` wherever is possible, and replaced `write!` with alloc-only equivalent in a few places. I also fixed some of the clippy warnings along the way in the parts of the code that I've touched.

If that's something you're interested in having upstream, I'll bring in a follow-up PR the final support for `no_std`, with a feature-flag propagating into dependencies.

I do this work as an experiment to add Lua support into [Firefly Zero](https://github.com/firefly-zero/) handheld game console. We're compiling apps into non-wasi wasm environment (in case of Rust, wasm-unknown-unknown) but the mainstream Lua interpreter can be used only with Emscripten JS polyfill.